### PR TITLE
:zap: Add `--commit` scan option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ scan [flags]
   -b, --baseline string           Provide the path to an existing SARIF report to be used in the baseline state calculation
       --baseline-include-absent   Include in the output report the results from the baseline run that are absent in the current run
   -c, --changes                   Inspect uncommitted changes and report new problems
+      --commit string             Base changes commit to reset to, useful with --changes: analysis will be run only on changed files since commit X, 'reset' will be cancelled once the analysis is finished if the commit prefix does not contain CI prefix
       --fail-threshold string     Set the number of problems that will serve as a quality gate. If this number is reached, the inspection run is terminated with a non-zero exit code
       --disable-sanity            Skip running the inspections configured by the sanity profile
   -d, --source-directory string   Directory inside the project-dir directory must be inspected. If not specified, the whole project is inspected

--- a/core/common.go
+++ b/core/common.go
@@ -46,6 +46,7 @@ type QodanaOptions struct {
 	Script                string
 	FailThreshold         string
 	Changes               bool
+	Commit                string
 	SendReport            bool
 	AnalysisId            string
 	Env                   []string

--- a/core/git.go
+++ b/core/git.go
@@ -1,0 +1,38 @@
+package core
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// IsGitInstalled checks if git is installed.
+func IsGitInstalled() bool {
+	_, err := exec.LookPath("git")
+	if err != nil {
+		WarningMessage(
+			"Unable to find git, refer to https://git-scm.com/downloads for installing it, no --commit option will be used",
+		)
+		return false
+	}
+	return true
+}
+
+// GitReset resets the git repository to the given commit.
+func git(cwd string, command []string) error {
+	cmd := exec.Command("git", command...)
+	cmd.Dir = cwd
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// GitReset resets the git repository to the given commit.
+func GitReset(cwd string, sha string) error {
+	return git(cwd, []string{"reset", "--soft", strings.TrimPrefix(sha, "CI")})
+}
+
+// GitResetBack aborts the git revert.
+func GitResetBack(cwd string) error {
+	return git(cwd, []string{"reset", "'HEAD@{1}'"})
+}


### PR DESCRIPTION
From https://github.com/JetBrains/Qodana/discussions/96: we need a mode to checkout the repository to and then run Qodana with --changes inside it.

For CLI the commit could be selected manually, but for GitHub action / others we'll get the variables from the environment / service.

Two cases when using the new option:
- Used locally 
  - Revert to the base commit with all changes kept (== soft reset), 
  - Run analysis
  - Abort revert 
- Used in CI 
  - Revert to the base commit with all changes kept (== soft reset), 
  - Run analysis

P.S. Used in CI use-case: commit begins with `CI` – special prefix for CI extensions, no way to mess it with any other commit random SHA256, because SHA256 can't contain `I` symbol, did it to skip adding yet another option to the pile of options for skipping revert abortion to not to waste time on big repositories.