### PR TITLE
:bug: Don't run exclude plugins logic in container, since it was already computed

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -179,8 +179,8 @@ func TestContributorsCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 	total := mapData["total"].(float64)
-	if total != 8 {
-		t.Fatalf("expected total 8, but got %f", total)
+	if total != 9 {
+		t.Fatalf("expected total 9, but got %f", total)
 	}
 }
 


### PR DESCRIPTION
Take into the consideration plugins that should be installed and don't ignore them.

