### PR TITLE
:bug: Do not run the publisher twice for container

### DIFF
--- a/core/ide.go
+++ b/core/ide.go
@@ -220,7 +220,7 @@ func runQodanaLocal(opts *QodanaOptions) int {
 	if opts.SaveReport || opts.ShowReport {
 		saveReport(opts)
 	}
-	if cloud.Token.IsAllowedToSendReports() {
+	if cloud.Token.IsAllowedToSendReports() && !IsContainer() {
 		SendReport(opts, cloud.Token.Token)
 	}
 	postAnalysis(opts)


### PR DESCRIPTION
# Pull Request Details


## Description

- @KoT9R bundled the publisher to the linters starting from 2023.3
- CLI is being run as an entrypoint in all of the latest 2023.3 images
- Once the publisher is bundled to the latest installers, this pull request should be merged
- Note: this functionality will be removed after 2023.3 release and CLI switch to 2023.3 version.

## Related Issue

https://youtrack.jetbrains.com/issue/QD-5059/

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [x] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
