### PR TITLE
:wastebasket: Deprecate `stub-profile` flag (QD-6638)

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,6 +108,30 @@ func TestHelp(t *testing.T) {
 
 	if expected != actual {
 		t.Fatalf("expected \"%s\" got \"%s\"", expected, actual)
+	}
+}
+
+func TestDeprecatedScanFlags(t *testing.T) {
+	deprecations := []string{"fixes-strategy", "stub-profile"}
+
+	out := bytes.NewBufferString("")
+	command := newScanCommand()
+	command.SetOut(out)
+	command.SetArgs([]string{"--help"})
+	err := command.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := io.ReadAll(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(raw)
+
+	for _, dep := range deprecations {
+		if strings.Contains(output, dep) {
+			t.Fatalf("Deprecated flag in output %s", dep)
+		}
 	}
 }
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -147,11 +147,11 @@ But you can always override qodana.yaml options with the following command-line 
 	cmd.MarkFlagsMutuallyExclusive("profile-name", "profile-path")
 	cmd.MarkFlagsMutuallyExclusive("apply-fixes", "cleanup")
 
-	err := cmd.Flags().MarkHidden("fixes-strategy")
+	err := cmd.Flags().MarkDeprecated("fixes-strategy", "use --apply-fixes / --cleanup instead")
 	if err != nil {
 		return nil
 	}
-	err = cmd.Flags().MarkDeprecated("fixes-strategy", "use --apply-fixes / --cleanup instead")
+	err = cmd.Flags().MarkDeprecated("stub-profile", "this option has no effect and no replacement")
 	if err != nil {
 		return nil
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -56,32 +56,37 @@ func TestCliArgs(t *testing.T) {
 		{
 			name: "typical set up",
 			opts: &QodanaOptions{ProjectDir: projectDir, CacheDir: cacheDir, ResultsDir: resultsDir, Linter: "jetbrains/qodana-jvm-community:latest", SourceDirectory: "./src", DisableSanity: true, RunPromo: "true", Baseline: "qodana.sarif.json", BaselineIncludeAbsent: true, SaveReport: true, ShowReport: true, Port: 8888, Property: []string{"foo.baz=bar", "foo.bar=baz"}, Script: "default", FailThreshold: "0", AnalysisId: "id", Env: []string{"A=B"}, Volumes: []string{"/tmp/foo:/tmp/foo"}, User: "1001:1001", PrintProblems: true, ProfileName: "Default", ApplyFixes: true},
-			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--stub-profile", filepath.Join(cacheDir, "profile.xml"), "--save-report", "--source-directory", "./src", "--disable-sanity", "--profile-name", "Default", "--run-promo", "true", "--baseline", "qodana.sarif.json", "--baseline-include-absent", "--fail-threshold", "0", "--fixes-strategy", "apply", "--analysis-id", "id", "--property=foo.baz=bar", "--property=foo.bar=baz", projectDir, resultsDir},
+			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--save-report", "--source-directory", "./src", "--disable-sanity", "--profile-name", "Default", "--run-promo", "true", "--baseline", "qodana.sarif.json", "--baseline-include-absent", "--fail-threshold", "0", "--fixes-strategy", "apply", "--analysis-id", "id", "--property=foo.baz=bar", "--property=foo.bar=baz", projectDir, resultsDir},
 		},
 		{
 			name: "arguments with spaces, no properties for local runs",
 			opts: &QodanaOptions{ProjectDir: projectDir, CacheDir: cacheDir, ResultsDir: resultsDir, ProfileName: "separated words", Property: []string{"qodana.format=SARIF_AND_PROJECT_STRUCTURE", "qodana.variable.format=JSON"}, Ide: Prod.Home},
-			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--stub-profile", filepath.Join(cacheDir, "profile.xml"), "--profile-name", "\"separated words\"", projectDir, resultsDir},
+			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--profile-name", "\"separated words\"", projectDir, resultsDir},
 		},
 		{
 			name: "deprecated --fixes-strategy=apply",
 			opts: &QodanaOptions{ProjectDir: projectDir, CacheDir: cacheDir, ResultsDir: resultsDir, FixesStrategy: "apply"},
-			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--stub-profile", filepath.Join(cacheDir, "profile.xml"), "--fixes-strategy", "apply", projectDir, resultsDir},
+			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--fixes-strategy", "apply", projectDir, resultsDir},
 		},
 		{
 			name: "deprecated --fixes-strategy=cleanup",
 			opts: &QodanaOptions{ProjectDir: projectDir, CacheDir: cacheDir, ResultsDir: resultsDir, FixesStrategy: "cleanup"},
-			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--stub-profile", filepath.Join(cacheDir, "profile.xml"), "--fixes-strategy", "cleanup", projectDir, resultsDir},
+			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--fixes-strategy", "cleanup", projectDir, resultsDir},
 		},
 		{
 			name: "--fixes-strategy=apply for new versions",
 			opts: &QodanaOptions{ProjectDir: projectDir, CacheDir: cacheDir, ResultsDir: resultsDir, FixesStrategy: "apply", Ide: "/opt/idea/233"},
-			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--stub-profile", filepath.Join(cacheDir, "profile.xml"), "--apply-fixes", projectDir, resultsDir},
+			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--apply-fixes", projectDir, resultsDir},
 		},
 		{
 			name: "--fixes-strategy=cleanup for new versions",
 			opts: &QodanaOptions{ProjectDir: projectDir, CacheDir: cacheDir, ResultsDir: resultsDir, FixesStrategy: "cleanup", Ide: "/opt/idea/233"},
-			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--stub-profile", filepath.Join(cacheDir, "profile.xml"), "--cleanup", projectDir, resultsDir},
+			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--cleanup", projectDir, resultsDir},
+		},
+		{
+			name: "--stub-profile ignored",
+			opts: &QodanaOptions{StubProfile: "ignored", ProjectDir: projectDir, CacheDir: cacheDir, ResultsDir: resultsDir, FixesStrategy: "cleanup", Ide: "/opt/idea/233"},
+			res:  []string{filepath.FromSlash("/opt/idea/bin/idea.sh"), "inspect", "qodana", "--cleanup", projectDir, resultsDir},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/core/ide.go
+++ b/core/ide.go
@@ -228,7 +228,7 @@ func runQodanaLocal(opts *QodanaOptions) int {
 }
 
 func getIdeRunCommand(opts *QodanaOptions) []string {
-	args := []string{QuoteForWindows(Prod.IdeScript), "inspect", "qodana", "--stub-profile", QuoteForWindows(opts.stabProfilePath())}
+	args := []string{QuoteForWindows(Prod.IdeScript), "inspect", "qodana"}
 	args = append(args, getIdeArgs(opts)...)
 	args = append(args, QuoteForWindows(opts.ProjectDir), QuoteForWindows(opts.ResultsDir))
 	return args
@@ -257,9 +257,6 @@ func getIdeArgs(opts *QodanaOptions) []string {
 	}
 	if opts.Script != "" && opts.Script != "default" {
 		arguments = append(arguments, "--script", opts.Script)
-	}
-	if opts.StubProfile != "" {
-		arguments = append(arguments, "--stub-profile", opts.StubProfile)
 	}
 	if opts.Baseline != "" {
 		arguments = append(arguments, "--baseline", QuoteForWindows(opts.Baseline))

--- a/core/options.go
+++ b/core/options.go
@@ -37,7 +37,7 @@ type QodanaOptions struct {
 	ProfileName           string
 	ProfilePath           string
 	RunPromo              string
-	StubProfile           string
+	StubProfile           string // note: deprecated option
 	Baseline              string
 	BaselineIncludeAbsent bool
 	SaveReport            bool
@@ -165,10 +165,6 @@ func (o *QodanaOptions) ReportDirPath() string {
 		}
 	}
 	return o.ReportDir
-}
-
-func (o *QodanaOptions) stabProfilePath() string {
-	return filepath.Join(o.CacheDirPath(), "profile.xml")
 }
 
 func (o *QodanaOptions) ReportResultsPath() string {


### PR DESCRIPTION
# Pull Request Details

Removes the `--stub-profile` flag from generated application args, remove default `profile.xml` argument too.

## Description

The flag is considered legacy and is being removed from Qodana. If users still supply the flag, a notice is logged.

On a side note, it's my first time writing golang, so I'm happy for any pointers. :)

## How Has This Been Tested

Ran qodana locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

It's a deprecation.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [x] My change requires a change to the [documentation](https://jetbrains.com/help/qodana). When implemented on IDE side
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
