### PR TITLE
:bug: Docker container should support /data/coverage as coverage directory.

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -170,6 +170,17 @@ func (o *QodanaOptions) ReportDirPath() string {
 	return o.ReportDir
 }
 
+func (o *QodanaOptions) CoverageDirPath() string {
+	if o.CoverageDir == "" {
+		if IsContainer() {
+			o.CoverageDir = "/data/coverage"
+		} else {
+			o.CoverageDir = filepath.Join(o.ProjectDir, ".qodana", "code-coverage")
+		}
+	}
+	return o.CoverageDir
+}
+
 func (o *QodanaOptions) ReportResultsPath() string {
 	return filepath.Join(o.ReportDirPath(), "results")
 }

--- a/core/properties.go
+++ b/core/properties.go
@@ -141,7 +141,7 @@ func GetProperties(opts *QodanaOptions, yamlProps map[string]string, dotNetOptio
 		getDeviceIdSalt(),
 		plugins,
 		opts.AnalysisId,
-		opts.CoverageDir,
+		opts.CoverageDirPath(),
 	)
 	for k, v := range yamlProps { // qodana.yaml – overrides vmoptions
 		if !strings.HasPrefix(k, "-") {


### PR DESCRIPTION
Lost during migration from endpoint.

