### PR TITLE
:children_crossing: Add possibility to set TFMs for qodana-dotnet.

### DIFF
--- a/core/properties.go
+++ b/core/properties.go
@@ -102,6 +102,12 @@ func getPropertiesMap(
 		if dotNet.Platform != "" {
 			properties["-Dqodana.net.platform"] = dotNet.Platform
 		}
+		if dotNet.Frameworks != "" {
+			properties["-Dqodana.net.targetFrameworks"] = dotNet.Frameworks
+		} else if IsContainer() {
+			// We don't want to scan .NET Framework projects in Linux containers
+			properties["-Dqodana.net.targetFrameworks"] = "!net48;!net472;!net471;!net47;!net462;!net461;!net46;!net452;!net451;!net45;!net403;!net40;!net35;!net20;!net11"
+		}
 	}
 
 	log.Debugf("properties: %v", properties)

--- a/core/yaml.go
+++ b/core/yaml.go
@@ -237,6 +237,9 @@ type DotNet struct {
 
 	// Platform is the target platform in which .NET project should be opened by Qodana.
 	Platform string `yaml:"platform,omitempty"`
+
+	// Frameworks is a semicolon-separated list of target framework monikers (TFM) to be analyzed.
+	Frameworks string `yaml:"frameworks,omitempty"`
 }
 
 // IsEmpty checks whether the .NET configuration is empty or not.


### PR DESCRIPTION
By default in container we will disable .NET Framework completely.

