### PR TITLE
QD-7787 Disable project opening via activities flag

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1150,6 +1150,7 @@ func TestQodanaOptions_RequiresToken(t *testing.T) {
 func propertiesFixture(enableStats bool, additionalProperties []string) []string {
 	properties := []string{
 		"-Dfus.internal.reduce.initial.delay=true",
+		"-Dide.warmup.use.predicates=false",
 		fmt.Sprintf("-Didea.application.info.value=%s", filepath.Join(os.TempDir(), "entrypoint", "QodanaAppInfo.xml")),
 		"-Didea.class.before.app=com.jetbrains.rider.protocol.EarlyBackendStarter",
 		fmt.Sprintf("-Didea.config.path=%s", filepath.Join(os.TempDir(), "entrypoint")),
@@ -1280,7 +1281,7 @@ func Test_Properties(t *testing.T) {
 		},
 		{
 			name:          "override options from CLI, YAML should be ignored",
-			cliProperties: []string{"-Dfus.internal.reduce.initial.delay=false", "-Didea.application.info.value=0", "idea.headless.enable.statistics=false"},
+			cliProperties: []string{"-Dfus.internal.reduce.initial.delay=false", "-Dide.warmup.use.predicates=true", "-Didea.application.info.value=0", "idea.headless.enable.statistics=false"},
 			qodanaYaml: "" +
 				"version: \"1.0\"\n" +
 				"properties:\n" +
@@ -1289,8 +1290,9 @@ func Test_Properties(t *testing.T) {
 			isContainer: false,
 			expected: append([]string{
 				"-Dfus.internal.reduce.initial.delay=false",
+				"-Dide.warmup.use.predicates=true",
 				"-Didea.application.info.value=0",
-			}, propertiesFixture(false, []string{})[2:]...),
+			}, propertiesFixture(false, []string{})[3:]...),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/core/properties.go
+++ b/core/properties.go
@@ -65,6 +65,7 @@ func getPropertiesMap(
 		"-Didea.log.path":                        QuoteIfSpace(logDir),
 		"-Didea.qodana.thirdpartyplugins.accept": "true",
 		"-Dqodana.automation.guid":               QuoteIfSpace(analysisId),
+		"-Dide.warmup.use.predicates":            "false",
 
 		"-XX:SoftRefLRUPolicyMSPerMB": "50",
 		"-XX:MaxJavaStackTraceDepth":  "10000",


### PR DESCRIPTION
- in qodana we don't open project via activities, flag must be enabled when we would want to do that
- see in intellij f036cf057bed40c54545826909e27f090667af06 com.jetbrains.python.sdk.PythonSdkUpdater#dropUpdaterInHeadless

# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
