### PR TITLE
:recycle: Align contributor counting with qodana cloud

### DIFF
--- a/core/contributors_test.go
+++ b/core/contributors_test.go
@@ -23,15 +23,19 @@ func TestGetContributors(t *testing.T) {
 	if len(contributors) == 0 {
 		t.Error("Expected at least one contributor or you need to update the test repo")
 	}
-	found := false
-	for _, c := range contributors {
-		if c.Author.Username == "dependabot[bot]" {
-			found = true
-			break
-		}
-	}
-	if !found {
+
+	numBotContributors := countContributors(func(c contributor) bool {
+		return c.Author.Username == "dependabot[bot]"
+	}, contributors)
+	if numBotContributors < 1 {
 		t.Error("Expected dependabot[bot] contributor")
+	}
+
+	numContributorsWithSameEmail := countContributors(func(c contributor) bool {
+		return c.Author.Email == "dmitry.golovinov@jetbrains.com"
+	}, contributors)
+	if numContributorsWithSameEmail < 2 {
+		t.Error("Expected contributor with same email but different username to be counted multiple times")
 	}
 }
 
@@ -57,4 +61,14 @@ func TestParseCommits(t *testing.T) {
 	if commits[1].Date != expectedDate {
 		t.Errorf("Expected date %s, got %s", expectedDate, commits[1].Date)
 	}
+}
+
+func countContributors(matches func(contributor) bool, contributors []contributor) int {
+	result := 0
+	for _, c := range contributors {
+		if matches(c) {
+			result += 1
+		}
+	}
+	return result
 }

--- a/core/git.go
+++ b/core/git.go
@@ -67,7 +67,7 @@ func gitOutput(cwd string, args []string) []string {
 }
 
 // gitLog returns the git log of the given repository in the given format.
-func gitLog(cwd string, format string, since int, mailmap bool) []string {
+func gitLog(cwd string, format string, since int) []string {
 	args := []string{"--no-pager", "log"}
 	if format != "" {
 		args = append(args, "--pretty=format:"+format)
@@ -75,15 +75,12 @@ func gitLog(cwd string, format string, since int, mailmap bool) []string {
 	if since > 0 {
 		args = append(args, fmt.Sprintf("--since=%d.days", since))
 	}
-	if mailmap {
-		args = append(args, "--mailmap")
-	}
 	return gitOutput(cwd, args)
 }
 
 // gitRevisions returns the list of commits of the git repository in chronological order.
 func gitRevisions(cwd string) []string {
-	return reverse(gitLog(cwd, "%H", 0, false))
+	return reverse(gitLog(cwd, "%H", 0))
 }
 
 // gitRemoteUrl returns the remote url of the git repository.


### PR DESCRIPTION
# Pull Request Details

Changes made to align with contributor counting in qodana cloud:

- Stop using mailmap
- Always ignore qodana bot when counting contributors
- Count contributors by unique (email + username)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
