### PR TITLE
Temporarily disable scanning in smart mode

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1364,6 +1364,7 @@ func propertiesFixture(enableStats bool, additionalProperties []string) []string
 		"-Dqodana.starter.profile.resource=qodana-dotnet.starter.yaml",
 		"-Drider.collect.full.container.statistics=true",
 		"-Drider.suppress.std.redirect=true",
+		"-Dscanning.in.smart.mode=false",
 		"-Dsun.io.useCanonCaches=false",
 		"-Dsun.tools.attach.tmp.only=true",
 		"-XX:+HeapDumpOnOutOfMemoryError",

--- a/core/properties.go
+++ b/core/properties.go
@@ -75,6 +75,7 @@ func getPropertiesMap(
 		"-XX:MaxRAMPercentage":        "70",
 
 		"-Didea.job.launcher.without.timeout": "true",
+		"-Dscanning.in.smart.mode":            "false",
 	}
 	if coverageDir != "" {
 		properties["-Dqodana.coverage.input"] = quoteIfSpace(coverageDir)


### PR DESCRIPTION
# Pull Request Details

This is the cause for the current issues in IJ runs. Tests fail because the JDK was not configured correctly, which is not completely true - the mechanism tries to resolve `java.lang.Object`, but this fails because indexes are not yet ready. Thus the JDK is treated as invalid.