### PR TITLE
:sparkles: Add new way running qodana on a diff

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -457,7 +457,7 @@ func Test_Bootstrap(t *testing.T) {
 	}
 	opts.ProjectDir = tmpDir
 	platform.Bootstrap("echo 'bootstrap: touch qodana.yml' > qodana.yaml", opts.ProjectDir)
-	config := platform.GetQodanaYaml(tmpDir)
+	config := platform.GetQodanaYamlOrDefault(tmpDir)
 	platform.Bootstrap(config.Bootstrap, opts.ProjectDir)
 	if _, err := os.Stat(filepath.Join(opts.ProjectDir, "qodana.yaml")); errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("No qodana.yml created by the bootstrap command in qodana.yaml")
@@ -997,7 +997,7 @@ func Test_Properties(t *testing.T) {
 				t.Fatal(err)
 			}
 			opts.Property = tc.cliProperties
-			qConfig := platform.GetQodanaYaml(opts.ProjectDir)
+			qConfig := platform.GetQodanaYamlOrDefault(opts.ProjectDir)
 			if tc.isContainer {
 				err = os.Setenv(platform.QodanaDockerEnv, "true")
 				if err != nil {

--- a/core/ide.go
+++ b/core/ide.go
@@ -73,9 +73,8 @@ func runQodanaLocal(opts *QodanaOptions) (int, error) {
 		postAnalysis(opts)
 		return res, err
 	}
-	if opts.SaveReport || opts.ShowReport {
-		saveReport(opts)
-	}
+
+	saveReport(opts)
 	postAnalysis(opts)
 	return res, err
 }
@@ -181,6 +180,14 @@ func GetIdeArgs(opts *QodanaOptions) []string {
 			if opts.ClangArgs != "" {
 				arguments = append(arguments, "--clang-args", opts.ClangArgs)
 			}
+		}
+	}
+
+	if opts.DiffStart != "" && opts.DiffEnd != "" {
+		if opts.Ide == "" {
+			arguments = append(arguments, "--diff-start", opts.DiffStart, "--diff-end", opts.DiffEnd)
+		} else {
+			arguments = append(arguments, "--script", platform.QuoteForWindows("scoped:"+opts.DiffScopeFile))
 		}
 	}
 

--- a/core/ide.go
+++ b/core/ide.go
@@ -350,16 +350,13 @@ func prepareLocalIdeSettings(opts *QodanaOptions) {
 		opts.LogDirPath(),
 		opts.ConfDirPath(),
 	)
-	platform.Config = platform.GetQodanaYaml(opts.ProjectDir) // TODO: Burry it!
+	platform.Config = platform.GetQodanaYamlOrDefault(opts.ProjectDir) // TODO: Burry it!
 	writeProperties(opts)
 
 	if platform.IsContainer() {
 		syncIdeaCache(opts.CacheDir, opts.ProjectDir, false)
 		createUser("/etc/passwd")
 	}
-
-	platform.Bootstrap(platform.Config.Bootstrap, opts.ProjectDir)
-	installPlugins(platform.Config.Plugins)
 }
 
 func prepareDirectories(cacheDir string, logDir string, confDir string) {

--- a/core/properties.go
+++ b/core/properties.go
@@ -183,6 +183,7 @@ func GetProperties(opts *QodanaOptions, yamlProps map[string]string, dotNetOptio
 
 // writeProperties writes the given key=value `props` to file `f` (sets the environment variable)
 func writeProperties(opts *QodanaOptions) { // opts.confDirPath(Prod.Version)  opts.vmOptionsPath(Prod.Version)
+	// TODO: in native mode we override vm options too?
 	properties := GetProperties(opts, platform.Config.Properties, platform.Config.DotNet, getPluginIds(platform.Config.Plugins))
 	err := os.WriteFile(opts.vmOptionsPath(), []byte(strings.Join(properties, "\n")), 0o644)
 	if err != nil {

--- a/core/properties.go
+++ b/core/properties.go
@@ -183,7 +183,6 @@ func GetProperties(opts *QodanaOptions, yamlProps map[string]string, dotNetOptio
 
 // writeProperties writes the given key=value `props` to file `f` (sets the environment variable)
 func writeProperties(opts *QodanaOptions) { // opts.confDirPath(Prod.Version)  opts.vmOptionsPath(Prod.Version)
-	// TODO: in native mode we override vm options too?
 	properties := GetProperties(opts, platform.Config.Properties, platform.Config.DotNet, getPluginIds(platform.Config.Plugins))
 	err := os.WriteFile(opts.vmOptionsPath(), []byte(strings.Join(properties, "\n")), 0o644)
 	if err != nil {

--- a/linter/run.go
+++ b/linter/run.go
@@ -32,7 +32,7 @@ func (o *CltOptions) Setup(_ *platform.QodanaOptions) error {
 
 func (o *CltOptions) RunAnalysis(opts *platform.QodanaOptions) error {
 	options := &LocalOptions{opts}
-	yaml := platform.GetQodanaYaml(options.ProjectDir)
+	yaml := platform.GetQodanaYamlOrDefault(options.ProjectDir)
 	platform.Bootstrap(yaml.Bootstrap, options.ProjectDir)
 	args, err := o.computeCdnetArgs(opts, options, yaml)
 	if err != nil {

--- a/platform/argflags.go
+++ b/platform/argflags.go
@@ -69,6 +69,9 @@ func ComputeFlags(cmd *cobra.Command, options *QodanaOptions) error {
 	flags.IntVar(&options.AnalysisTimeoutMs, "timeout", -1, "Qodana analysis time limit in milliseconds. If reached, the analysis is terminated, process exits with code timeout-exit-code. Negative – no timeout")
 	flags.IntVar(&options.AnalysisTimeoutExitCode, "timeout-exit-code", 1, "See timeout option")
 
+	flags.StringVar(&options.DiffStart, "diff-start", "", "Commit to start an incremental run from. Only files changed between --diff-start and --diff-end will be analysed.")
+	flags.StringVar(&options.DiffEnd, "diff-end", "", "Commit to end an incremental run on. Only files changed between --diff-start and --diff-end will be analysed.")
+
 	if options.LinterSpecific != nil {
 		if linterSpecific, ok := options.LinterSpecific.(ThirdPartyOptions); ok {
 			linterSpecific.AddFlags(flags)
@@ -86,6 +89,8 @@ func ComputeFlags(cmd *cobra.Command, options *QodanaOptions) error {
 		cmd.MarkFlagsMutuallyExclusive("user", "ide")
 		cmd.MarkFlagsMutuallyExclusive("env", "ide")
 	}
+
+	cmd.MarkFlagsRequiredTogether("diff-start", "diff-end")
 
 	cmd.MarkFlagsMutuallyExclusive("commit", "script")
 	cmd.MarkFlagsMutuallyExclusive("profile-name", "profile-path")

--- a/platform/git.go
+++ b/platform/git.go
@@ -92,3 +92,7 @@ func GitRemoteUrl(cwd string) string {
 func GitBranch(cwd string) string {
 	return gitOutput(cwd, []string{"rev-parse", "--abbrev-ref", "HEAD"})[0]
 }
+
+func GitDiffNameOnly(cwd string, diffStart string, diffEnd string) []string {
+	return gitOutput(cwd, []string{"diff", "--name-only", diffStart, diffEnd})
+}

--- a/platform/options.go
+++ b/platform/options.go
@@ -55,6 +55,9 @@ type QodanaOptions struct {
 	Script                  string
 	FailThreshold           string
 	Commit                  string
+	DiffStart               string
+	DiffEnd                 string
+	DiffScopeFile           string
 	AnalysisId              string
 	Env                     []string
 	Volumes                 []string

--- a/platform/yaml.go
+++ b/platform/yaml.go
@@ -19,6 +19,7 @@ package platform
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	"os"
@@ -41,22 +42,31 @@ func GetQodanaYamlPath(project string) (string, error) {
 	return qodanaYamlPath, nil
 }
 
-// GetQodanaYaml reads qodana.yaml or qodana.yml
-func GetQodanaYaml(project string) QodanaYaml {
+// GetQodanaYaml returns a parsed qodana.yaml or qodana.yml or error if not found/invalid
+func GetQodanaYaml(project string) (QodanaYaml, error) {
 	q := &QodanaYaml{}
 	qodanaYamlPath, err := GetQodanaYamlPath(project)
 	if err != nil {
-		return *q
+		return *q, err
 	}
 	yamlFile, err := os.ReadFile(qodanaYamlPath)
 	if err != nil {
-		log.Printf("Problem loading qodana.yaml: %v ", err)
+		return *q, err
 	}
 	err = yaml.Unmarshal(yamlFile, q)
 	if err != nil {
-		log.Printf("Not a valid qodana.yaml: %v ", err)
+		return *q, fmt.Errorf("not a valid qodana.yaml: %w", err)
 	}
-	return *q
+	return *q, nil
+}
+
+// GetQodanaYamlOrDefault reads qodana.yaml or qodana.yml and returns an empty config if not found or invalid
+func GetQodanaYamlOrDefault(project string) QodanaYaml {
+	q, err := GetQodanaYaml(project)
+	if err != nil {
+		log.Printf("Problem loading qodana.yaml: %v ", err)
+	}
+	return q
 }
 
 // QodanaYaml A standard qodana.yaml (or qodana.yml) format for Qodana configuration.


### PR DESCRIPTION
# Pull Request Details

See QD-8139 - a new of running qodana on a diff of files. When passed the args ` --diff-start` and `--diff-end`, cli will checkout the respective commits, run bootstrap and the linter. In the first run, we don't apply fixes or show results, but use the report as baseline for the second run.

I'm still thinking about making these inner bootstraps a separate config property. Probably we also want to run the first one as defined by in the commit of `--diff-start` and the second one by `--diff-end`. Also need to look into testing still