### PR TITLE
:bug: Prepare directories for each diff run

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -280,6 +280,12 @@ func runOnCommitRange(ctx context.Context, options *QodanaOptions) int {
 		if e != nil {
 			log.Fatalf("Cannot checkout commit %s: %v", hash, e)
 		}
+
+		prepareDirectories(
+			options.CacheDir,
+			options.LogDirPath(),
+			options.ConfDirPath(),
+		)
 		log.Infof("Analysing %s", hash)
 		writeProperties(options)
 


### PR DESCRIPTION
Log dir implicitly depends on results dir, which we change for each run. Only caught this when running on a new project, else the directories existed before
