### PR TITLE
:sparkles: Prefer 'scoped' over 'local-changes' in .NET

### DIFF
--- a/core/ide.go
+++ b/core/ide.go
@@ -123,9 +123,6 @@ func GetIdeArgs(opts *QodanaOptions) []string {
 	if opts.FailThreshold != "" {
 		arguments = append(arguments, "--fail-threshold", opts.FailThreshold)
 	}
-	if opts.GitReset && opts.Commit != "" && opts.Script == "default" {
-		arguments = append(arguments, "--script", "local-changes")
-	}
 
 	if opts.fixesSupported() {
 		if opts.FixesStrategy != "" {
@@ -187,15 +184,17 @@ func GetIdeArgs(opts *QodanaOptions) []string {
 		}
 	}
 
-	if opts.DiffStart != "" && opts.DiffEnd != "" {
-		if opts.Ide == "" {
-			arguments = append(arguments, "--diff-start", opts.DiffStart, "--diff-end", opts.DiffEnd)
-		} else {
-			arguments = append(arguments, "--script", platform.QuoteForWindows("scoped:"+opts.DiffScopeFile))
-		}
-	}
-
 	if opts.Ide == "" {
+		if startHash, err := opts.StartHash(); startHash != "" && err == nil && opts.Script == "default" {
+			arguments = append(arguments, "--diff-start", startHash)
+		}
+		if opts.DiffEnd != "" && opts.Script == "default" {
+			arguments = append(arguments, "--diff-end", opts.DiffEnd)
+		}
+		if opts.ForceIncrementalScript != "" && opts.Script == "default" {
+			arguments = append(arguments, "--force-incremental-script", opts.ForceIncrementalScript)
+		}
+
 		if opts.AnalysisId != "" {
 			arguments = append(arguments, "--analysis-id", opts.AnalysisId)
 		}

--- a/core/run_scenario.go
+++ b/core/run_scenario.go
@@ -26,7 +26,7 @@ const (
 	runScenarioDefault      = "default"
 	runScenarioFullHistory  = "full-history"
 	runScenarioLocalChanges = "local-changes"
-	runScenarioScoped       = "scoped"
+	runScenarioScoped       = "scope"
 )
 
 type RunScenario = string

--- a/core/run_scenario.go
+++ b/core/run_scenario.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2024 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"github.com/JetBrains/qodana-cli/v2024/platform"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+const (
+	runScenarioDefault      = "default"
+	runScenarioFullHistory  = "full-history"
+	runScenarioLocalChanges = "local-changes"
+	runScenarioScoped       = "scoped"
+)
+
+type RunScenario = string
+
+func (o *QodanaOptions) determineRunScenario(hasStartHash bool) RunScenario {
+	switch o.ForceIncrementalScript {
+	case "":
+		isDotNet := Prod.Code == platform.QDNET || strings.Contains(o.Linter, "dotnet")
+		switch {
+		case o.FullHistory:
+			return runScenarioFullHistory
+		case hasStartHash && isDotNet:
+			return runScenarioScoped
+		case hasStartHash && !isDotNet:
+			return runScenarioLocalChanges
+		default:
+			return runScenarioDefault
+		}
+	case platform.IncrementalScriptLocalChanges:
+		if !hasStartHash {
+			log.Fatal("Cannot run any incremental script without --diff-start/--commit")
+		}
+		return runScenarioLocalChanges
+	case platform.IncrementalScriptScope:
+		if !hasStartHash {
+			log.Fatal("Cannot run any incremental script without --diff-start/--commit")
+		}
+		return runScenarioScoped
+	default:
+		log.Fatalf("Unknown forced incremental script %s", o.ForceIncrementalScript)
+		panic("Unreachable")
+	}
+}

--- a/core/run_scenario_test.go
+++ b/core/run_scenario_test.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021-2024 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"github.com/JetBrains/qodana-cli/v2024/platform"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestQodanaOptions_determineRunScenario(t *testing.T) {
+	type args struct {
+		qodanaOptions *platform.QodanaOptions
+		productCode   string
+		hasStartHash  bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want RunScenario
+	}{
+		{
+			name: "full history for .NET",
+			args: args{
+				qodanaOptions: &platform.QodanaOptions{
+					FullHistory: true,
+				},
+				hasStartHash: true,
+				productCode:  platform.QDNET,
+			},
+			want: runScenarioFullHistory,
+		},
+		{
+			name: "full history for not .NET",
+			args: args{
+				qodanaOptions: &platform.QodanaOptions{
+					FullHistory: true,
+				},
+				hasStartHash: true,
+				productCode:  platform.QDJVM,
+			},
+			want: runScenarioFullHistory,
+		},
+		{
+			name: "default .NET",
+			args: args{
+				qodanaOptions: &platform.QodanaOptions{},
+				hasStartHash:  false,
+				productCode:   platform.QDNET,
+			},
+			want: runScenarioDefault,
+		},
+		{
+			name: "default not .NET",
+			args: args{
+				qodanaOptions: &platform.QodanaOptions{},
+				hasStartHash:  false,
+				productCode:   platform.QDJVM,
+			},
+			want: runScenarioDefault,
+		},
+		{
+			name: "with start hash .NET",
+			args: args{
+				qodanaOptions: &platform.QodanaOptions{},
+				hasStartHash:  true,
+				productCode:   platform.QDNET,
+			},
+			want: runScenarioScoped,
+		},
+		{
+			name: "with start hash not .NET",
+			args: args{
+				qodanaOptions: &platform.QodanaOptions{},
+				hasStartHash:  true,
+				productCode:   platform.QDJVM,
+			},
+			want: runScenarioLocalChanges,
+		},
+		{
+			name: "forced script",
+			args: args{
+				qodanaOptions: &platform.QodanaOptions{
+					ForceIncrementalScript: platform.IncrementalScriptLocalChanges,
+				},
+				hasStartHash: true,
+				productCode:  platform.QDNET,
+			},
+			want: runScenarioLocalChanges,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := Prod.Code
+			Prod.Code = tt.args.productCode
+			defer func() { Prod.Code = code }()
+			o := QodanaOptions{QodanaOptions: tt.args.qodanaOptions}
+			assert.Equalf(t, tt.want, o.determineRunScenario(tt.args.hasStartHash), "determineRunScenario(%v)", tt.args.hasStartHash)
+		})
+	}
+}

--- a/platform/argflags.go
+++ b/platform/argflags.go
@@ -48,7 +48,7 @@ func ComputeFlags(cmd *cobra.Command, options *QodanaOptions) error {
 	flags.StringVarP(&options.Baseline, "baseline", "b", "", "Provide the path to an existing SARIF report to be used in the baseline state calculation")
 	flags.BoolVar(&options.BaselineIncludeAbsent, "baseline-include-absent", false, "Include in the output report the results from the baseline run that are absent in the current run")
 	flags.BoolVar(&options.FullHistory, "full-history", false, "Go through the full commit history and run the analysis on each commit. If combined with `--commit`, analysis will be started from the given commit. Could take a long time.")
-	flags.StringVar(&options.Commit, "commit", "", "Base changes commit to reset to, resets git and runs linter with `--script local-changes`: analysis will be run only on changed files since the given commit. If combined with `--full-history`, full history analysis will be started from the given commit.")
+	flags.StringVar(&options.Commit, "commit", "", "Base changes commit to reset to, resets git and runs an incremental analysis: analysis will be run only on changed files since the given commit. If combined with `--full-history`, full history analysis will be started from the given commit.")
 	flags.StringVar(&options.FailThreshold, "fail-threshold", "", "Set the number of problems that will serve as a quality gate. If this number is reached, the inspection run is terminated with a non-zero exit code")
 	flags.BoolVar(&options.DisableSanity, "disable-sanity", false, "Skip running the inspections configured by the sanity profile")
 	flags.StringVarP(&options.SourceDirectory, "source-directory", "d", "", "Directory inside the project-dir directory must be inspected. If not specified, the whole project is inspected")
@@ -71,6 +71,7 @@ func ComputeFlags(cmd *cobra.Command, options *QodanaOptions) error {
 
 	flags.StringVar(&options.DiffStart, "diff-start", "", "Commit to start an incremental run from. Only files changed between --diff-start and --diff-end will be analysed.")
 	flags.StringVar(&options.DiffEnd, "diff-end", "", "Commit to end an incremental run on. Only files changed between --diff-start and --diff-end will be analysed.")
+	flags.StringVar(&options.ForceIncrementalScript, "force-incremental-script", "", "Override the default run-scenario for incremental runs. Allowed values are `local-changes` and `scope`. Note that the given scenario might not be compatible with the linter.")
 
 	flags.IntVar(&options.JvmDebugPort, "jvm-debug-port", -1, "Enable JVM remote debug under given port")
 	if options.LinterSpecific != nil {
@@ -91,9 +92,8 @@ func ComputeFlags(cmd *cobra.Command, options *QodanaOptions) error {
 		cmd.MarkFlagsMutuallyExclusive("env", "ide")
 	}
 
-	cmd.MarkFlagsRequiredTogether("diff-start", "diff-end")
-
-	cmd.MarkFlagsMutuallyExclusive("commit", "script")
+	cmd.MarkFlagsMutuallyExclusive("script", "force-incremental-script", "full-history")
+	cmd.MarkFlagsMutuallyExclusive("commit", "script", "diff-start")
 	cmd.MarkFlagsMutuallyExclusive("profile-name", "profile-path")
 	cmd.MarkFlagsMutuallyExclusive("apply-fixes", "cleanup")
 

--- a/platform/git.go
+++ b/platform/git.go
@@ -96,3 +96,7 @@ func GitBranch(cwd string) string {
 func GitDiffNameOnly(cwd string, diffStart string, diffEnd string) []string {
 	return gitOutput(cwd, []string{"diff", "--name-only", diffStart, diffEnd})
 }
+
+func GitCurrentRevision(cwd string) string {
+	return gitOutput(cwd, []string{"rev-parse", "HEAD"})[0]
+}

--- a/platform/options.go
+++ b/platform/options.go
@@ -31,6 +31,11 @@ import (
 	"unicode"
 )
 
+const (
+	IncrementalScriptLocalChanges = "local-changes"
+	IncrementalScriptScope        = "scope"
+)
+
 // QodanaOptions is a struct that contains all the options to run a Qodana linter.
 type QodanaOptions struct {
 	ResultsDir              string
@@ -57,7 +62,7 @@ type QodanaOptions struct {
 	Commit                  string
 	DiffStart               string
 	DiffEnd                 string
-	DiffScopeFile           string
+	ForceIncrementalScript  string
 	AnalysisId              string
 	Env                     []string
 	Volumes                 []string
@@ -179,6 +184,19 @@ func (o *QodanaOptions) Unsetenv(key string) {
 			o.Env = append(o.Env[:i], o.Env[i+1:]...)
 			return
 		}
+	}
+}
+
+func (o *QodanaOptions) StartHash() (string, error) {
+	switch {
+	case o.Commit == o.DiffStart:
+		return o.Commit, nil
+	case o.Commit == "":
+		return o.DiffStart, nil
+	case o.DiffStart == "":
+		return o.Commit, nil
+	default:
+		return "", fmt.Errorf("conflicting CLI arguments: --commit=%s --diff-start=%s", o.Commit, o.DiffStart)
 	}
 }
 


### PR DESCRIPTION
# Pull Request Details

As outlined in slack:
- Make `--commit` an alias of `--diff-start`
- Default `--diff-end` to `git rev-parse HEAD`
- Add a new flag `--force-incremental-script`
- Prefer scoped script for .NET, old local changes for everything else

I did not go and deprecate `--commit`, because it turns out to be quite a hassle: For every combination of cli and linter, we'd need to figure out what to pass to avoid deprecation notices and ensure compatibility
