### PR TITLE
:zap: Filter out non-supported linters by license plan (QD-8272)

### DIFF
--- a/cloud/license.go
+++ b/cloud/license.go
@@ -58,6 +58,7 @@ const (
 	qodanaLicenseUri       = "/linters/license-key"
 	QodanaToken            = "QODANA_TOKEN"
 	QodanaLicenseOnlyToken = "QODANA_LICENSE_ONLY_TOKEN"
+	CommunityLicensePlan   = "COMMUNITY"
 )
 
 var TokenDeclinedError = errors.New("token was declined by Qodana Cloud server")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -47,7 +47,7 @@ func newInitCommand() *cobra.Command {
 				if platform.IsInteractive() && !platform.AskUserConfirm(fmt.Sprintf("Do you want to set up Qodana in %s", platform.PrimaryBold(options.ProjectDir))) {
 					return
 				}
-				analyzer := platform.GetAnalyzer(options.ProjectDir, options.ConfigName)
+				analyzer := platform.GetAnalyzer(options.ProjectDir, options.ConfigName, options.GetToken())
 				if platform.IsNativeAnalyzer(analyzer) {
 					options.Ide = analyzer
 				} else {

--- a/core/ide.go
+++ b/core/ide.go
@@ -351,7 +351,7 @@ func prepareLocalIdeSettings(opts *QodanaOptions) {
 
 	platform.ExtractQodanaEnvironment(platform.SetEnv)
 	requiresToken := opts.RequiresToken(Prod.EAP || Prod.IsCommunity())
-	cloud.SetupLicenseToken(opts.LoadToken(false, requiresToken))
+	cloud.SetupLicenseToken(opts.LoadToken(false, requiresToken, true))
 	SetupLicenseAndProjectHash(cloud.GetCloudApiEndpoints(), cloud.Token.Token)
 	prepareDirectories(
 		opts.CacheDir,

--- a/platform/options.go
+++ b/platform/options.go
@@ -127,6 +127,11 @@ func (o *QodanaOptions) LogOptions() {
 	log.Debug(buffer.String())
 }
 
+// GetToken default options function to obtain token (no user interaction)
+func (o *QodanaOptions) GetToken() string {
+	return o.LoadToken(false, o.RequiresToken(false), false)
+}
+
 func (o *QodanaOptions) FetchAnalyzerSettings() {
 	if o.Linter == "" && o.Ide == "" {
 		qodanaYaml := LoadQodanaYaml(o.ProjectDir, o.ConfigName)
@@ -136,7 +141,7 @@ func (o *QodanaOptions) FetchAnalyzerSettings() {
 				PrimaryBold(o.ConfigName),
 				PrimaryBold("qodana init"),
 			)
-			analyzer := GetAnalyzer(o.ProjectDir, o.ConfigName)
+			analyzer := GetAnalyzer(o.ProjectDir, o.ConfigName, o.GetToken())
 			if IsNativeAnalyzer(analyzer) {
 				o.Ide = analyzer
 			} else {

--- a/platform/run.go
+++ b/platform/run.go
@@ -42,14 +42,14 @@ func setup(options *QodanaOptions) error {
 		return fmt.Errorf("failed to get java executable path: %w", err)
 	}
 	// TODO iscommunityoreap
-	cloud.SetupLicenseToken(options.LoadToken(false, options.RequiresToken(false)))
+	cloud.SetupLicenseToken(options.GetToken())
 	options.LicensePlan, err = cloud.GetCloudApiEndpoints().GetLicensePlan()
 	if err != nil {
 		if !linterInfo.IsEap {
 			return fmt.Errorf("failed to get license plan: %w", err)
 		}
 		println("Qodana license plan: EAP license.")
-		options.LicensePlan = "COMMUNITY"
+		options.LicensePlan = cloud.CommunityLicensePlan
 	}
 
 	options.ResultsDir, err = filepath.Abs(options.ResultsDir)


### PR DESCRIPTION
# Pull Request Details

This PR addresses https://youtrack.jetbrains.com/issue/QD-8272/

## Description

We would filter out incompatible linters based on the license plan if the token was provided.
If the token is not provided, the behavior will be the same. 
- We do not try/ask users to explicitly provide the token so as not to break the UX that was before. But if the token was provided, we will do an additional check on the linters selection and won't suggest incompatible products
- I want this to change as minimal as possible, without massive refactorings just before the release, so the proposed solution is not the best one possible, but is about keeping as less things touched as possible

## Related Issue

https://youtrack.jetbrains.com/issue/QD-8272/

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [x] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
