### PR TITLE
:sparkles: QD-8811 Non-bundled plugin now should be stored in "custom…

### DIFF
--- a/core/ide.go
+++ b/core/ide.go
@@ -438,6 +438,14 @@ func prepareDirectories(cacheDir string, logDir string, confDir string) {
 			}
 		}
 	}
+
+	disabledPluginsPathSrc := filepath.Join(Prod.Home, "disabled_plugins.txt")
+	disabledPluginsPathDst := filepath.Join(confDir, "disabled_plugins.txt")
+	if _, err := os.Stat(disabledPluginsPathSrc); err == nil {
+		if err := cp.Copy(disabledPluginsPathSrc, disabledPluginsPathDst); err != nil {
+			log.Fatal(err)
+		}
+	}
 }
 
 // installPlugins runs plugin installer for every plugin id in qodana.yaml.

--- a/core/product_info.go
+++ b/core/product_info.go
@@ -70,6 +70,10 @@ func (p *product) IdeBin() string {
 	return filepath.Join(p.Home, "bin")
 }
 
+func (p *product) CustomPluginsPath() string {
+	return filepath.Join(p.Home, "custom-plugins")
+}
+
 func (p *product) javaHome() string {
 	return filepath.Join(p.Home, "jbr")
 }

--- a/core/properties.go
+++ b/core/properties.go
@@ -141,6 +141,11 @@ func GetProperties(opts *QodanaOptions, yamlProps map[string]string, dotNetOptio
 		lines = append(lines, "-Deap.require.license=release")
 	}
 
+	customPluginPathsValue := getCustomPluginPaths()
+	if customPluginPathsValue != "" {
+		lines = append(lines, fmt.Sprintf("-Dplugin.path=%s", customPluginPathsValue))
+	}
+
 	cliProps, flags := opts.Properties()
 	for _, f := range flags {
 		if f != "" && !platform.Contains(lines, f) {
@@ -182,6 +187,22 @@ func GetProperties(opts *QodanaOptions, yamlProps map[string]string, dotNetOptio
 	sort.Strings(lines)
 
 	return lines
+}
+
+func getCustomPluginPaths() string {
+	path := Prod.CustomPluginsPath()
+
+	var paths string
+	files, err := os.ReadDir(path)
+	for _, file := range files {
+		paths += filepath.Join(path, file.Name()) + ","
+	}
+	paths = strings.TrimSuffix(paths, ",")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	return paths
 }
 
 // writeProperties writes the given key=value `props` to file `f` (sets the environment variable)

--- a/core/properties.go
+++ b/core/properties.go
@@ -191,21 +191,19 @@ func GetProperties(opts *QodanaOptions, yamlProps map[string]string, dotNetOptio
 
 func getCustomPluginPaths() string {
 	path := Prod.CustomPluginsPath()
-	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return ""
 	}
-	var paths string
-	files, err := os.ReadDir(path)
-	for _, file := range files {
-		paths += filepath.Join(path, file.Name()) + ","
-	}
-	paths = strings.TrimSuffix(paths, ",")
 
+	files, err := os.ReadDir(path)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return paths
+	var paths []string
+	for _, file := range files {
+		paths = append(paths, filepath.Join(path, file.Name()))
+	}
+	return strings.Join(paths, ",")
 }
 
 // writeProperties writes the given key=value `props` to file `f` (sets the environment variable)

--- a/core/properties.go
+++ b/core/properties.go
@@ -191,7 +191,10 @@ func GetProperties(opts *QodanaOptions, yamlProps map[string]string, dotNetOptio
 
 func getCustomPluginPaths() string {
 	path := Prod.CustomPluginsPath()
-
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return ""
+	}
 	var paths string
 	files, err := os.ReadDir(path)
 	for _, file := range files {


### PR DESCRIPTION
…-plugins" instead "plugins". Plugins are passed for loading through property "plugin.path".

# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
