### PR TITLE
:bug: Fix check for updates versioning

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -85,7 +85,7 @@ func getLatestVersion() string {
 	if err != nil {
 		return ""
 	}
-	return result["tag_name"].(string)
+	return strings.TrimPrefix(result["tag_name"].(string), "v")
 }
 
 // OpenDir opens directory in the default file manager


### PR DESCRIPTION
Well, we did update how we set version, but we left `v` inside the update check..

```bash
qodana --version
qodana version 2024.1.1

!  New version of qodana CLI is available: v2024.1.1. See https://jb.gg/qodana-cli/update


!  New version of qodana CLI is available: v2024.1.1. See https://jb.gg/qodana-cli/update
```