### PR TITLE
:bug: Do not write `qodana.yaml` when not using `init` command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -47,7 +47,7 @@ func newInitCommand() *cobra.Command {
 				if platform.IsInteractive() && !platform.AskUserConfirm(fmt.Sprintf("Do you want to set up Qodana in %s", platform.PrimaryBold(options.ProjectDir))) {
 					return
 				}
-				analyzer := platform.GetAnalyzer(options.ProjectDir, options.ConfigName, options.GetToken())
+				analyzer := platform.GetAnalyzer(options.ProjectDir, options.ConfigName, options.GetToken(), true)
 				if platform.IsNativeAnalyzer(analyzer) {
 					options.Ide = analyzer
 				} else {

--- a/platform/common.go
+++ b/platform/common.go
@@ -85,7 +85,7 @@ func QodanaLogo(toolDesc string, version string, eap bool) string {
 }
 
 // GetAnalyzer gets linter for the given path and saves a config
-func GetAnalyzer(path string, yamlName string, token string) string {
+func GetAnalyzer(path string, yamlName string, token string, writeYaml bool) string {
 	var analyzers []string
 	PrintProcess(func(_ *pterm.SpinnerPrinter) {
 		languages := readIdeaDir(path)
@@ -126,8 +126,10 @@ func GetAnalyzer(path string, yamlName string, token string) string {
 		WarningMessage("See https://www.jetbrains.com/help/qodana/supported-technologies.html for more details")
 		os.Exit(1)
 	}
-	SetQodanaLinter(path, analyzer, yamlName)
-	SuccessMessage("Added %s", analyzer)
+	if writeYaml {
+		SetQodanaLinter(path, analyzer, yamlName)
+	}
+	SuccessMessage("Selected %s", analyzer)
 	return analyzer
 }
 

--- a/platform/options.go
+++ b/platform/options.go
@@ -142,7 +142,7 @@ func (o *QodanaOptions) FetchAnalyzerSettings() {
 				PrimaryBold(qodanaYamlPath),
 				PrimaryBold("qodana init"),
 			)
-			analyzer := GetAnalyzer(o.ProjectDir, qodanaYamlPath, o.GetToken())
+			analyzer := GetAnalyzer(o.ProjectDir, qodanaYamlPath, o.GetToken(), false)
 			if IsNativeAnalyzer(analyzer) {
 				o.Ide = analyzer
 			} else {


### PR DESCRIPTION
# Pull Request Details

We write `qodana.yaml` when running various commands. 
It's wrong when it's working in various scenarios that are not `init` subcommand.
For example, when users have quick fixes enabled, we would try to commit the newly produced file when users do not expect it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [x] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
