### PR TITLE
:bug: analysis-id no longer added to qodana send args when the ID is empty

### DIFF
--- a/platform/publisher.go
+++ b/platform/publisher.go
@@ -84,11 +84,17 @@ func getPublisherArgs(java string, publisher string, opts *QodanaOptions, token 
 		QuoteForWindows(java),
 		"-jar",
 		QuoteForWindows(publisher),
-		"--analysis-id", opts.AnalysisId,
+	}
+
+	if opts.AnalysisId != "" {
+		publisherArgs = append(publisherArgs, "--analysis-id", opts.AnalysisId)
+	}
+
+	publisherArgs = append(publisherArgs,
 		"--sources-path", QuoteForWindows(opts.ProjectDir),
 		"--report-path", QuoteForWindows(opts.ReportResultsPath()),
-		"--token", token,
-	}
+		"--token", token)
+
 	var tools []string
 	tool := os.Getenv(QodanaToolEnv)
 	if tool != "" {

--- a/platform/publisher_test.go
+++ b/platform/publisher_test.go
@@ -64,10 +64,45 @@ func TestGetPublisherArgs(t *testing.T) {
 
 	// Assert that the expected arguments are present
 	expectedArgs := []string{
-		java,
+		QuoteForWindows(java),
 		"-jar",
 		"test-publisher.jar",
 		"--analysis-id", "test-analysis-id",
+		"--sources-path", "/path/to/project",
+		"--report-path", filepath.FromSlash("/path/to/report/results"),
+		"--token", "test-token",
+		"--tool", "test-tool",
+		"--endpoint", "test-endpoint",
+	}
+	if !reflect.DeepEqual(publisherArgs, expectedArgs) {
+		t.Errorf("getPublisherArgs returned incorrect arguments: got %v, expected %v", publisherArgs, expectedArgs)
+	}
+}
+
+func TestGetPublisherArgsNoAnalysisId(t *testing.T) {
+	// Set up test options
+	opts := &QodanaOptions{
+		AnalysisId: "",
+		ProjectDir: "/path/to/project",
+		ResultsDir: "/path/to/results",
+		ReportDir:  "/path/to/report",
+	}
+
+	// Set up test environment variables
+	err := os.Setenv(QodanaToolEnv, "test-tool")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	java, _ := getJavaExecutablePath()
+	// Call the function being tested
+	publisherArgs := getPublisherArgs(java, "test-publisher.jar", opts, "test-token", "test-endpoint")
+
+	// Assert that the expected arguments are present
+	expectedArgs := []string{
+		QuoteForWindows(java),
+		"-jar",
+		"test-publisher.jar",
 		"--sources-path", "/path/to/project",
 		"--report-path", filepath.FromSlash("/path/to/report/results"),
 		"--token", "test-token",


### PR DESCRIPTION
# Pull Request Details

When the command-line argument string is generated for the publication step of `qodana send`, an empty analysis ID in the options would before result in a malformed argument string, whereas it will now result in the whole argument (name and value) being omitted.

Before this change, an empty analysis ID would result in the argument string containing something like this:

`... --analysis-id --sources-path . ...`

After this change, an empty analysis ID results in:

`... --sources-path . ...`

<!--- Describe your changes in detail -->

## Related Issue

See [QD-9111](https://youtrack.jetbrains.com/issue/QD-9111/Missing-analysis-id-in-qodana-send).

## Motivation and Context

I (and my colleagues) have been unable to publish locally-created Qodana results to the cloud. The origin of the problem was due to our empty analysis ID causing a generated command-line argument string to be malformed, resulting in a misleading error reading "Error: Got unexpected extra argument (.)".

This fix has resolved this, by omitting the argument name when the ID is empty.

## How Has This Been Tested

I successfully published my results to our cloud instance. I also ran the tests in `platform/publisher_test.go`, and wrote an additional test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
