### PR TITLE
Update to go 1.22.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           touch cdnet/clt.zip tooling/baseline-cli.jar tooling/intellij-report-converter.jar tooling/qodana-fuser.jar
           cat > go.work << EOF
-          go 1.21.13
+          go 1.22.8
           
           use (
           ./cdnet
@@ -84,7 +84,7 @@ jobs:
         run: |
           touch cdnet/clt.zip tooling/baseline-cli.jar tooling/intellij-report-converter.jar tooling/qodana-fuser.jar
           cat > go.work << EOF
-          go 1.21.13
+          go 1.22.8
 
           use (
           ./cdnet

--- a/cdnet/go.mod
+++ b/cdnet/go.mod
@@ -1,6 +1,6 @@
 module github.com/JetBrains/qodana-cli/v2024/cdnet
 
-go 1.21.13
+go 1.22.8
 
 replace (
 	github.com/JetBrains/qodana-cli/v2024/cmd => ../cmd

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/JetBrains/qodana-cli/v2024/cli
 
-go 1.21.13
+go 1.22.8
 
 require (
 	github.com/boyter/scc/v3 v3.3.5 // indirect

--- a/cloud/go.mod
+++ b/cloud/go.mod
@@ -1,6 +1,6 @@
 module github.com/JetBrains/qodana-cli/v2024/cloud
 
-go 1.21.13
+go 1.22.8
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/JetBrains/qodana-cli/v2024/cmd
 
-go 1.21.13
+go 1.22.8
 
 require (
 	github.com/JetBrains/qodana-cli/v2024/cloud v0.0.0-00010101000000-000000000000
@@ -114,4 +114,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/JetBrains/qodana-cli/v2024/core
 
-go 1.21.13
+go 1.22.8
 
 require (
 	github.com/cucumber/ci-environment/go v0.0.0-20230911180507-bd001ebc644c

--- a/platform/go.mod
+++ b/platform/go.mod
@@ -1,6 +1,6 @@
 module github.com/JetBrains/qodana-cli/v2024/platform
 
-go 1.21.13
+go 1.22.8
 
 require (
 	github.com/cucumber/ci-environment/go v0.0.0-20230911180507-bd001ebc644c

--- a/sarif/go.mod
+++ b/sarif/go.mod
@@ -1,3 +1,3 @@
 module github.com/JetBrains/qodana-cli/v2024/sarif
 
-go 1.21.13
+go 1.22.8

--- a/tooling/go.mod
+++ b/tooling/go.mod
@@ -1,3 +1,3 @@
 module github.com/JetBrains/qodana-cli/v2024/tooling
 
-go 1.21.13
+go 1.22.8


### PR DESCRIPTION
Related to #176

Update Go version to 1.22.8 across multiple modules and CI workflow.

* **Modules:**
  - Update `go` directive to `1.22.8` in `cdnet/go.mod`, `cli/go.mod`, `cloud/go.mod`, `cmd/go.mod`, `core/go.mod`, `platform/go.mod`, `sarif/go.mod`, and `tooling/go.mod`.

* **CI Workflow:**
  - Update `go.work` content to use `go 1.22.8` in `.github/workflows/ci.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JetBrains/qodana-cli/issues/176?shareId=b19dbed9-0604-4953-af67-cb6e1062e61f).