### PR TITLE
:bug: QD-10590 Plugins must be installed only inside native mode (ins…

### DIFF
--- a/core/ide.go
+++ b/core/ide.go
@@ -404,6 +404,9 @@ func prepareDirectories(cacheDir string, logDir string, confDir string) {
 
 // installPlugins runs plugin installer for every plugin id in qodana.yaml.
 func installPlugins(opts *QodanaOptions, plugins []platform.Plugin) {
+	if !opts.IsNative() {
+		return
+	}
 	if len(plugins) > 0 {
 		setInstallPluginsVmoptions(opts)
 	}

--- a/platform/options.go
+++ b/platform/options.go
@@ -395,3 +395,7 @@ func (o *QodanaOptions) GetSarifPath() string {
 func (o *QodanaOptions) GetShortSarifPath() string {
 	return path.Join(o.ResultsDir, "qodana-short.sarif.json")
 }
+
+func (o *QodanaOptions) IsNative() bool {
+	return o.Ide != ""
+}


### PR DESCRIPTION
…ide docker is native)

(cherry picked from commit 2d09e71fa7d9bfd48c45b25748c0f7b4890b1c56)

# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
