### PR TITLE
:bug: Fix setting `--report-dir` for container runs (QD-10890)

### DIFF
--- a/cdnet/options_test.go
+++ b/cdnet/options_test.go
@@ -17,9 +17,11 @@
 package main
 
 import (
+	"fmt"
 	"github.com/JetBrains/qodana-cli/v2025/core"
 	"github.com/JetBrains/qodana-cli/v2025/core/corescan"
 	"github.com/JetBrains/qodana-cli/v2025/platform/product"
+	"github.com/JetBrains/qodana-cli/v2025/platform/qdcontainer"
 	"github.com/JetBrains/qodana-cli/v2025/platform/qdyaml"
 	"github.com/JetBrains/qodana-cli/v2025/platform/thirdpartyscan"
 	"github.com/JetBrains/qodana-cli/v2025/platform/utils"
@@ -258,7 +260,10 @@ func TestComputeCdnetArgs(t *testing.T) {
 					"qodana.default.file.suspend.threshold=100000",
 					"qodana.default.module.suspend.threshold=100000",
 					"qodana.default.project.suspend.threshold=100000",
-					"idea.diagnostic.opentelemetry.file=/data/results/log/open-telemetry.json",
+					fmt.Sprintf(
+						"idea.diagnostic.opentelemetry.file=%s/log/open-telemetry.json",
+						qdcontainer.DataResultsDir,
+					),
 					"jetbrains.security.package-checker.synchronizationTimeout=1000",
 				},
 				ResultsDir:       "",

--- a/core/container.go
+++ b/core/container.go
@@ -299,6 +299,10 @@ func getDockerOptions(c corescan.Context) *backend.ContainerCreateConfig {
 	if err != nil {
 		log.Fatal("couldn't get abs path for results", err)
 	}
+	reportPath, err := filepath.Abs(c.ReportDir())
+	if err != nil {
+		log.Fatal("couldn't get abs path for report", err)
+	}
 	containerName = os.Getenv(qdenv.QodanaCliContainerName)
 	if containerName == "" {
 		containerName = fmt.Sprintf("qodana-cli-%s", c.Id())
@@ -318,6 +322,11 @@ func getDockerOptions(c corescan.Context) *backend.ContainerCreateConfig {
 			Type:   mount.TypeBind,
 			Source: resultsPath,
 			Target: "/data/results",
+		},
+		{
+			Type:   mount.TypeBind,
+			Source: reportPath,
+			Target: "/data/results/report",
 		},
 	}
 	if c.GlobalConfigurationsDir() != "" {

--- a/core/container.go
+++ b/core/container.go
@@ -53,8 +53,6 @@ const (
 	officialImagePrefix      = "jetbrains/qodana"
 	dockerSpecialCharsLength = 8
 	containerJvmDebugPort    = "5005"
-	// when container is launched by CLI, qodana-global-configurations.yaml file is mounted here
-	globalConfigDirContainerMountPath = "/data/qodana-global-config/"
 )
 
 var (
@@ -311,22 +309,22 @@ func getDockerOptions(c corescan.Context) *backend.ContainerCreateConfig {
 		{
 			Type:   mount.TypeBind,
 			Source: cachePath,
-			Target: "/data/cache",
+			Target: qdcontainer.DataCacheDir,
 		},
 		{
 			Type:   mount.TypeBind,
 			Source: projectPath,
-			Target: "/data/project",
+			Target: qdcontainer.DataProjectDir,
 		},
 		{
 			Type:   mount.TypeBind,
 			Source: resultsPath,
-			Target: "/data/results",
+			Target: qdcontainer.DataResultsDir,
 		},
 		{
 			Type:   mount.TypeBind,
 			Source: reportPath,
-			Target: "/data/results/report",
+			Target: qdcontainer.DataResultsReportDir,
 		},
 	}
 	if c.GlobalConfigurationsDir() != "" {
@@ -342,7 +340,7 @@ func getDockerOptions(c corescan.Context) *backend.ContainerCreateConfig {
 			volumes, mount.Mount{
 				Type:   mount.TypeBind,
 				Source: globalConfigDirAbsPath,
-				Target: globalConfigDirContainerMountPath,
+				Target: qdcontainer.DataGlobalConfigDir,
 			},
 		)
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -26,6 +26,7 @@ import (
 	platformcmd "github.com/JetBrains/qodana-cli/v2025/platform/cmd"
 	"github.com/JetBrains/qodana-cli/v2025/platform/commoncontext"
 	"github.com/JetBrains/qodana-cli/v2025/platform/product"
+	"github.com/JetBrains/qodana-cli/v2025/platform/qdcontainer"
 	"github.com/JetBrains/qodana-cli/v2025/platform/qdenv"
 	"github.com/JetBrains/qodana-cli/v2025/platform/qdyaml"
 	"github.com/JetBrains/qodana-cli/v2025/platform/tokenloader"
@@ -998,7 +999,7 @@ func propertiesFixture(enableStats bool, additionalProperties []string) []string
 		"-Didea.headless.statistics.device.id=FAKE",
 		"-Didea.headless.statistics.salt=FAKE",
 		"-Dqodana.automation.guid=FAKE",
-		"-Dqodana.coverage.input=/data/coverage",
+		fmt.Sprintf("-Dqodana.coverage.input=%s", qdcontainer.DataCoverageDir),
 		fmt.Sprintf("-Didea.log.path=%s", filepath.Join(os.TempDir(), "entrypoint", "log")),
 		fmt.Sprintf("-Didea.plugins.path=%s", filepath.Join(os.TempDir(), "entrypoint", "plugins", "233")),
 		fmt.Sprintf("-Didea.system.path=%s", filepath.Join(os.TempDir(), "entrypoint", "idea", "233")),
@@ -1131,7 +1132,7 @@ func Test_Properties(t *testing.T) {
 				context := corescan.CreateContext(
 					platformcmd.CliOptions{
 						Property:    tc.cliProperties,
-						CoverageDir: "/data/coverage",
+						CoverageDir: qdcontainer.DataCoverageDir,
 						AnalysisId:  "FAKE",
 					},
 					commonCtx,

--- a/core/corescan/create_context.go
+++ b/core/corescan/create_context.go
@@ -20,6 +20,7 @@ import (
 	"github.com/JetBrains/qodana-cli/v2025/core/startup"
 	"github.com/JetBrains/qodana-cli/v2025/platform/cmd"
 	"github.com/JetBrains/qodana-cli/v2025/platform/commoncontext"
+	"github.com/JetBrains/qodana-cli/v2025/platform/qdcontainer"
 	"github.com/JetBrains/qodana-cli/v2025/platform/qdenv"
 	"path/filepath"
 	"strings"
@@ -35,7 +36,7 @@ func CreateContext(
 	coverageDir := cliOptions.CoverageDir
 	if coverageDir == "" {
 		if qdenv.IsContainer() {
-			coverageDir = "/data/coverage"
+			coverageDir = qdcontainer.DataCoverageDir
 		} else {
 			coverageDir = filepath.Join(commonCtx.ProjectDir, ".qodana", "code-coverage")
 		}

--- a/core/ide.go
+++ b/core/ide.go
@@ -21,6 +21,7 @@ import (
 	"github.com/JetBrains/qodana-cli/v2025/core/startup"
 	"github.com/JetBrains/qodana-cli/v2025/platform"
 	"github.com/JetBrains/qodana-cli/v2025/platform/product"
+	"github.com/JetBrains/qodana-cli/v2025/platform/qdcontainer"
 	"github.com/JetBrains/qodana-cli/v2025/platform/utils"
 	"os"
 	"path/filepath"
@@ -209,7 +210,7 @@ func GetIdeArgs(c corescan.Context) []string {
 			arguments = append(arguments, "--jvm-debug-port", strconv.Itoa(c.JvmDebugPort()))
 		}
 		if c.GlobalConfigurationsDir() != "" {
-			arguments = append(arguments, "--global-config-dir", globalConfigDirContainerMountPath)
+			arguments = append(arguments, "--global-config-dir", qdcontainer.DataGlobalConfigDir)
 		}
 		if c.GlobalConfigurationId() != "" {
 			arguments = append(arguments, "--global-config-id", c.GlobalConfigurationId())

--- a/core/startup/prepare.go
+++ b/core/startup/prepare.go
@@ -69,6 +69,9 @@ func PrepareHost(commonCtx commoncontext.Context) PreparedHost {
 	if err := os.MkdirAll(commonCtx.ResultsDir, os.ModePerm); err != nil {
 		log.Fatal("couldn't create a directory ", err.Error())
 	}
+	if err := os.MkdirAll(commonCtx.ReportDir, os.ModePerm); err != nil {
+		log.Fatal("couldn't create a directory ", err.Error())
+	}
 	if commonCtx.Linter != "" {
 		qdcontainer.PrepareContainerEnvSettings()
 	}

--- a/core/startup/xml.go
+++ b/core/startup/xml.go
@@ -18,10 +18,12 @@ package startup
 
 import (
 	"fmt"
+	"github.com/JetBrains/qodana-cli/v2025/platform/qdcontainer"
 )
 
 func jdkTableXml(jdkPath string) string {
-	return fmt.Sprintf(`<application>
+	return fmt.Sprintf(
+		`<application>
   <component name="ProjectJdkTable">
     <jdk version="2">
       <name value="11" />
@@ -106,11 +108,13 @@ func jdkTableXml(jdkPath string) string {
     </jdk>
   </component>
 </application>
-`, jdkPath)
+`, jdkPath,
+	)
 }
 
 func androidProjectDefaultXml(androidSdkPath string) string {
-	return fmt.Sprintf(`<application>
+	return fmt.Sprintf(
+		`<application>
   <component name="ProjectManager">
     <defaultProject>
       <component name="PropertiesComponent">
@@ -118,7 +122,8 @@ func androidProjectDefaultXml(androidSdkPath string) string {
       </component>
     </defaultProject>
   </component>
-</application>`, androidSdkPath)
+</application>`, androidSdkPath,
+	)
 }
 
 const securityXml = `<application>
@@ -127,8 +132,9 @@ const securityXml = `<application>
     </component>
 </application>`
 
-const mavenSettingsXml = `<settings>
-    <localRepository>/data/cache/.m2</localRepository>
+var mavenSettingsXml = fmt.Sprintf(
+	`<settings>
+    <localRepository>%s/.m2</localRepository>
     <mirrors>
         <mirror>
             <id>cache-central</id>
@@ -162,13 +168,16 @@ const mavenSettingsXml = `<settings>
         </mirror>
     </mirrors>
 </settings>
-`
+`, qdcontainer.DataCacheDir,
+)
 
-const mavenPathMacroxXml = `<application>
+var mavenPathMacroxXml = fmt.Sprintf(
+	`<application>
     <component name="PathMacrosImpl">
-        <macro name="MAVEN_REPOSITORY" value="/data/cache/.m2" />
+        <macro name="MAVEN_REPOSITORY" value="%s/.m2" />
     </component>
-</application>`
+</application>`, qdcontainer.DataCacheDir,
+)
 
 const userPrefsXml = `?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE map SYSTEM "http://java.sun.com/dtd/preferences.dtd">

--- a/platform/commoncontext/compute.go
+++ b/platform/commoncontext/compute.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/JetBrains/qodana-cli/v2025/platform/msg"
 	"github.com/JetBrains/qodana-cli/v2025/platform/product"
+	"github.com/JetBrains/qodana-cli/v2025/platform/qdcontainer"
 	"github.com/JetBrains/qodana-cli/v2025/platform/qdenv"
 	"github.com/JetBrains/qodana-cli/v2025/platform/qdyaml"
 	"os"
@@ -155,7 +156,7 @@ func computeResultsDir(resultsDirFromCliOptions string, linterDir string) string
 		return resultsDirFromCliOptions
 	}
 	if qdenv.IsContainer() {
-		return "/data/results"
+		return qdcontainer.DataResultsDir
 	} else {
 		return filepath.Join(linterDir, "results")
 	}
@@ -166,7 +167,7 @@ func computeCacheDir(cacheDirFromCliOptions string, linterDir string) string {
 		return cacheDirFromCliOptions
 	}
 	if qdenv.IsContainer() {
-		return "/data/cache"
+		return qdcontainer.DataCacheDir
 	} else {
 		return filepath.Join(linterDir, "cache")
 	}
@@ -177,7 +178,7 @@ func computeReportDir(reportDirFromCliOptions string, resultsDir string) string 
 		return reportDirFromCliOptions
 	}
 	if qdenv.IsContainer() {
-		return "/data/results/report"
+		return qdcontainer.DataResultsReportDir
 	} else {
 		return filepath.Join(resultsDir, "report")
 	}

--- a/platform/qdcontainer/container.go
+++ b/platform/qdcontainer/container.go
@@ -29,6 +29,15 @@ import (
 	"strings"
 )
 
+const (
+	DataProjectDir       = "/data/project"
+	DataResultsDir       = "/data/results"
+	DataResultsReportDir = "/data/results/report"
+	DataCacheDir         = "/data/cache"
+	DataCoverageDir      = "/data/coverage"
+	DataGlobalConfigDir  = "/data/qodana-global-config/" // when container is launched by CLI, qodana-global-configurations.yaml file is mounted here
+)
+
 func checkRequiredToolInstalled(tool string) bool {
 	_, err := exec.LookPath(tool)
 	return err == nil


### PR DESCRIPTION
# Pull Request Details

https://youtrack.jetbrains.com/issue/QD-10890/report-dir-doesnt-save-the-report-directory

## Description

Fix setting the report dir for the container runs by mounting it to a specific default container path, as we allowed setting this option in CLI before and it was not effective.

## Related Issue

https://youtrack.jetbrains.com/issue/QD-10890/

## How Has This Been Tested

```
QODANA_TOKEN=... go run cli/main.go scan --report-dir here --log-level debug
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [x] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
