### PR TITLE
Revert ":zap: QD-11553 Mute test which verify existense of 2025 linte…

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -223,7 +223,6 @@ func TestPullInNative(t *testing.T) {
 }
 
 func TestAllCommandsWithContainer(t *testing.T) {
-	t.Skip("Muted until 2025.1 linters are not released")
 	version.Version = "0.1.0"
 	linter := "registry.jetbrains.team/p/sa/containers/qodana-dotnet:latest"
 
@@ -380,7 +379,6 @@ func TestAllCommandsWithContainer(t *testing.T) {
 }
 
 func TestScanWithIde(t *testing.T) {
-	t.Skip("Muted until 2025.1 linters are not released")
 	log.SetLevel(log.DebugLevel)
 	token := os.Getenv("QODANA_LICENSE_ONLY_TOKEN")
 	if token == "" {

--- a/core/startup/installers_test.go
+++ b/core/startup/installers_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestGetIde(t *testing.T) {
-	t.Skip("Muted until 2025.1 linters are not released")
 	//os.Setenv("QD_PRODUCT_INTERNAL_FEED", "https://data.services.jetbrains.com/products")
 	for _, installer := range product.AllNativeCodes {
 		ide := getIde(installer)
@@ -43,7 +42,6 @@ func TestGetIde(t *testing.T) {
 }
 
 func TestDownloadAndInstallIDE(t *testing.T) {
-	t.Skip("Muted until 2025.1 linters are not released")
 	ides := []string{"QDGO"}
 	for _, ide := range ides {
 		DownloadAndInstallIDE(ide, t)

--- a/core/startup/releases_test.go
+++ b/core/startup/releases_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestGetProductByCode(t *testing.T) {
-	t.Skip("Muted until 2025.1 linters are not released")
 	product, err := GetProductByCode("RD")
 	if err != nil {
 		t.Fatalf("Error getting product: %s", err)

--- a/platform/product/product.go
+++ b/platform/product/product.go
@@ -52,7 +52,7 @@ const (
 var (
 	VersionsMap = map[string]string{
 		ReleaseVer: "2025.1",
-		EapVer:     "2025.1",
+		EapVer:     "2024.3",
 	}
 
 	Products = map[string]string{


### PR DESCRIPTION
…rs in feed, because it's not yet released"

This reverts commit e8937a407f24a50a9ed113a67dd296ca0d516e33.

# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
