### PR TITLE
QD-11641: GitHub workflow yml file is missing permissions

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,4 +1,8 @@
 name: 'post-release'
+permissions:
+  contents: write
+  pull-requests: write
+  packages: read
 on:
   release:
     types: [released]


### PR DESCRIPTION
### 🛠️ Add explicit permissions to post-release GitHub Actions workflow

## Description

Added `permissions` to the `.github/workflows/post-release.yml` file to comply with GitHub Advanced Security best practices. This resolves a CodeQL finding which highlighted the lack of explicit permission declarations in the workflow.

## Related Issue

Fixes: *[insert issue link or number]*  
Issue: **`post-release.yml` is missing permissions.**

## Motivation and Context

GitHub Actions workflows that do not define permissions inherit repository-level defaults, which may include write access. This violates the principle of least privilege and may introduce unintended security risks. Adding explicit permissions ensures that the workflow only has access to what it needs.

## Changes Made

Added the following block to `.github/workflows/post-release.yml`:

```yaml
permissions:
  contents: write
  pull-requests: write
  packages: read
```

## How Has This Been Tested

No code logic was changed. The GitHub Actions workflow was verified to execute successfully after this addition.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
