### PR TITLE
:lipstick: QD-12365 Add warning about sensitive contents to generated yaml.

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -67,7 +67,7 @@ func newInitCommand() *cobra.Command {
 				token := qdenv.GetQodanaGlobalEnv(qdenv.QodanaToken)
 				analyzer := commoncontext.SelectAnalyzerForPath(cliOptions.ProjectDir, token)
 
-				writeQodanaLinterToYamlFile(
+				writeQodanaLinterToYamlFileWithWarning(
 					localQodanaYamlFullPath,
 					analyzer,
 				)
@@ -124,15 +124,15 @@ func checkToken(analyser product.Analyzer, cliOptions *initOptions) {
 	}
 }
 
-// WriteQodanaLinterToYamlFile adds the linter to the qodana.yaml file.
-func writeQodanaLinterToYamlFile(qodanaYamlFullPath string, analyser product.Analyzer) {
+// WriteQodanaLinterToYamlFile adds the linter to the qodana.yaml file, also adds warning about sensetive information
+func writeQodanaLinterToYamlFileWithWarning(qodanaYamlFullPath string, analyser product.Analyzer) {
 	q := qdyaml.LoadQodanaYamlByFullPath(qodanaYamlFullPath)
 	if q.Version == "" {
 		q.Version = "1.0"
 	}
 	q.Sort()
 	q = analyser.InitYaml(q)
-	err := q.WriteConfig(qodanaYamlFullPath)
+	err := q.WriteConfigWithWarning(qodanaYamlFullPath)
 	if err != nil {
 		log.Fatalf("writeConfig: %v", err)
 	}

--- a/platform/qdyaml/yaml.go
+++ b/platform/qdyaml/yaml.go
@@ -147,6 +147,29 @@ func (q *QodanaYaml) WriteConfig(path string) error {
 	return nil
 }
 
+const warningComment = `#################################################################################
+#              WARNING: Do not store sensitive information in this file,        #
+#               as its contents will be included in the Qodana report.          #
+#################################################################################
+`
+
+// WriteConfigWithWarning writes QodanaYaml with warning to the given path
+func (q *QodanaYaml) WriteConfigWithWarning(path string) error {
+	var b bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&b)
+	yamlEncoder.SetIndent(2)
+	err := yamlEncoder.Encode(&q)
+	if err != nil {
+		return err
+	}
+	out := append([]byte(warningComment), b.Bytes()...)
+	err = os.WriteFile(path, out, 0o600)
+	if err != nil {
+		log.Fatalf("Marshal: %v", err)
+	}
+	return nil
+}
+
 // Profile A profile is some template set of checks to run with Qodana analysis.
 //
 //goland:noinspection GoUnnecessarilyExportedIdentifiers


### PR DESCRIPTION
 Apply for init calls when no valid linter or ide is already specified