### PR TITLE
:bricks: QD-13376 Fix codex version to avoid stalling sessions

### DIFF
--- a/dockerfiles/jvm-llm/internal.Dockerfile
+++ b/dockerfiles/jvm-llm/internal.Dockerfile
@@ -16,7 +16,7 @@ RUN chmod +x $QODANA_DIST/bin/*.sh $QODANA_DIST/bin/qodana && \
 # Install Claude Code
 RUN curl -fsSL https://claude.ai/install.sh | bash && \
     chmod 777 -R $HOME && \
-    npm i -g @openai/codex && \
+    npm i -g @openai/codex@0.117 && \
     npm i -g mcp-remote
 
 


### PR DESCRIPTION
New codex versions have some bugs with sessions, so during our generation and pr analysis all sessions just hangs, fix concrete version to avoid this