### PR TITLE
:bricks: Add rust to Dockerfile auto-generation config

### DIFF
--- a/dockerfiles/public.json
+++ b/dockerfiles/public.json
@@ -58,5 +58,9 @@
   "ruby": {
     "qd_code": "QDRUBY",
     "description": "Qodana for Ruby (https://jb.gg/qodana-ruby)"
+  },
+  "rust": {
+    "qd_code": "QDRST",
+    "description": "Qodana for Rust (https://jb.gg/qodana-rust)"
   }
 }

--- a/scripts/dockerfiles.py
+++ b/scripts/dockerfiles.py
@@ -46,6 +46,7 @@ def load_release_info(qd_code: str, qd_version: str) -> Dict[str, Any]:
         "QDPYC": "qodana-python-community",
         "QDCPP": "qodana-cpp",
         "QDRUBY": "qodana-ruby",
+        "QDRST": "qodana-rust",
     }
 
     feed_name = product_mapping.get(qd_code)


### PR DESCRIPTION
## Summary

- Adds `rust` entry to [dockerfiles/public.json](../blob/main/dockerfiles/public.json) so [scripts/dockerfiles.py](../blob/main/scripts/dockerfiles.py)'s per-variant Dockerfile generator visits it. Rust was the only linter with full metadata in `product.go` (`QDRST`, `DockerImage: jetbrains/qodana-rust`, `EapOnly: true`) and a committed base image in `dockerfiles/base/` that was missing from `public.json` — an oversight from the original `QD-12546 Prepare qodana-docker for migration` commit.
- Adds `"QDRST": "qodana-rust"` to `product_mapping` in `scripts/dockerfiles.py` so the generator knows where to fetch release info. Mirrors the pattern used for the other EAP-only IntelliJ-based linter (Ruby → `qodana-ruby`).

## Effect on main

- **Config-only.** No `dockerfiles/rust/Dockerfile` ships in this PR. On \`main\`, zero \`dockerfiles/*/Dockerfile\` files currently exist (per-variant Dockerfiles are generated on release branches), so \`.github/workflows/lint.yml\`'s \`has_dockerfiles\` gate evaluates false and the regeneration path is skipped. This matches the existing main-branch convention.

## Effect on release branches after cherry-pick

- On \`261\` (where the lenient release-info fallback at \`scripts/dockerfiles.py:262-266\` is already in place), cherry-picking this change will trigger the lint workflow to auto-regenerate and auto-commit \`dockerfiles/rust/Dockerfile\` on the PR branch. \`.github/scripts/release-matrix.py\` will then include rust in the release matrix, and \`jetbrains/qodana-rust\` will begin publishing for \`linux/amd64\` and \`linux/arm64\`.
- Note: \`download.jetbrains.com/qodana/feed/qodana-rust.releases.json\` currently returns 404. On \`261\` the generated Dockerfile will therefore have empty \`QD_BUILD\` / \`QD_DOWNLOAD_URL_LINUX*\` args, and \`docker build\` will require \`--build-arg QD_RELEASE=<tag>\`. Publishing the public rust feed, or confirming the release workflow passes \`QD_RELEASE\`, is a prerequisite for the first green production build on 261.

## Test plan

- [x] \`python3 -c 'import json; json.load(open("dockerfiles/public.json"))'\` → valid JSON; \`rust\` entry present with \`qd_code=QDRST\`.
- [x] \`python3 -c 'import ast; ast.parse(open("scripts/dockerfiles.py").read())'\` → valid Python.
- [x] \`git diff origin/main\` shows exactly two hunks; no extraneous changes.
- [x] Pre-commit hooks (go-generate, golangci-lint, go-vet) pass locally.
- [ ] CI lint workflow runs (will skip generation on main per \`has_dockerfiles=false\` guard — expected).
- [ ] User confirms rust feed publication timing before cherry-picking to 261.