### PR TITLE
:bricks: QD-14440 Add rust to Dockerfile auto-generation config

### DIFF
--- a/dockerfiles/public.json
+++ b/dockerfiles/public.json
@@ -58,5 +58,9 @@
   "ruby": {
     "qd_code": "QDRUBY",
     "description": "Qodana for Ruby (https://jb.gg/qodana-ruby)"
+  },
+  "rust": {
+    "qd_code": "QDRST",
+    "description": "Qodana for Rust (https://jb.gg/qodana-rust)"
   }
 }

--- a/scripts/dockerfiles.py
+++ b/scripts/dockerfiles.py
@@ -46,6 +46,7 @@ def load_release_info(qd_code: str, qd_version: str) -> Dict[str, Any]:
         "QDPYC": "qodana-python-community",
         "QDCPP": "qodana-cpp",
         "QDRUBY": "qodana-ruby",
+        "QDRST": "qodana-rust",
     }
 
     feed_name = product_mapping.get(qd_code)


### PR DESCRIPTION
[QD-14440](https://youtrack.jetbrains.com/issue/QD-14440)

## Summary

- Adds `rust` entry to `dockerfiles/public.json` so `scripts/dockerfiles.py`'s per-variant Dockerfile generator visits it. Rust was the only linter with full metadata in `product.go` (`QDRST`, `DockerImage: jetbrains/qodana-rust`, `EapOnly: true`) and a committed base image in `dockerfiles/base/` that was missing from `public.json` — an oversight from the original `QD-12546 Prepare qodana-docker for migration` commit.
- Adds `"QDRST": "qodana-rust"` to `product_mapping` in `scripts/dockerfiles.py` so the generator knows where to fetch release info.

## Effect on main

Config-only. On `main`, zero `dockerfiles/*/Dockerfile` files currently exist (per-variant Dockerfiles are generated on release branches), so `.github/workflows/lint.yml`'s `has_dockerfiles` gate evaluates false and the regeneration path is skipped. Companion PR against `261` is where the Dockerfile actually gets generated and rust enters the release matrix.

## Test plan

- [x] `python3 -c 'import json; json.load(open("dockerfiles/public.json"))'` → valid JSON; `rust` entry present with `qd_code=QDRST`.
- [x] `python3 -c 'import ast; ast.parse(open("scripts/dockerfiles.py").read())'` → valid Python.
- [x] `git diff origin/main` shows exactly two hunks; no extraneous changes.
- [x] Pre-commit hooks (go-generate, golangci-lint, go-vet) pass locally.
- [ ] Lint workflow runs (will skip generation on main per `has_dockerfiles=false` — expected).