### PR TITLE
:bricks: QD-14442 Run GoReleaser from repo root and wire pre-generate hooks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,8 @@ builds:
       - amd64
       - arm64
     hooks:
+      pre:
+        - cmd: go generate -v ./cli/... ./internal/...
       post:
         - cmd: |
             bash -c "
@@ -60,6 +62,8 @@ builds:
       - amd64
       - arm64
     hooks:
+      pre:
+        - cmd: go generate -v ./clang/... ./internal/...
       post:
         - cmd: go run ./scripts/sign.go clang qodana-clang
 
@@ -82,6 +86,8 @@ builds:
       - amd64
       - arm64
     hooks:
+      pre:
+        - cmd: go generate -v ./cdnet/... ./internal/...
       post:
         - cmd: go run ./scripts/sign.go cdnet qodana-cdnet
 

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -47,7 +47,7 @@ class GoReleaser(
     name = "${releaseType.name} qodana-$wd"
     description = "${releaseType.name} $arguments build of qodana-$wd for ($CLI_GITHUB_REPO_URL/$branch)"
     maxRunningBuildsPerBranch = if (releaseType != ReleaseType.Snapshot) "*:1" else "*:0"
-    artifactRules = "${wd}/dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
+    artifactRules = "dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
 
     if (buildPattern.isNotEmpty()) {
         buildNumberPattern = buildPattern
@@ -95,17 +95,9 @@ class GoReleaser(
         }
         script {
             name = "Run GoReleaser"
-            workingDir = wd
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
                     set -e
-                    if [ -f "../.goreleaser.yaml" ]; then
-                        GORELEASER_CONFIG="../.goreleaser.yaml"
-                        PREFIX=".."
-                    else
-                        GORELEASER_CONFIG=".goreleaser.yaml"
-                        PREFIX="."
-                    fi
 
                     ARCH=${'$'}(uname -m)
                     case ${'$'}ARCH in
@@ -124,21 +116,14 @@ class GoReleaser(
                     chmod +x /usr/local/bin/codesign
 
                     export GORELEASER_CURRENT_TAG=${'$'}(git describe --tags ${'$'}(git rev-list --tags --max-count=1))
-                    goreleaser release --config ${'$'}GORELEASER_CONFIG --clean ${arguments.joinToString(" ")}
+                    goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """
                     set -e
-                    if [ -f "../.goreleaser.yaml" ]; then
-                        GORELEASER_CONFIG="../.goreleaser.yaml"
-                        PREFIX=".."
-                    else
-                        GORELEASER_CONFIG=".goreleaser.yaml"
-                        PREFIX="."
-                    fi
 
                     export GORELEASER_CURRENT_TAG=${'$'}(git describe --tags ${'$'}(git rev-list --tags --max-count=1))
-                    goreleaser release --config ${'$'}GORELEASER_CONFIG --clean ${arguments.joinToString(" ")}
+                    goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             }
 


### PR DESCRIPTION
Fixes [QD-14442](https://youtrack.jetbrains.com/issue/QD-14442). TeamCity Release build on branch 261 has been failing since build #28 with:

```
⨯ release failed after 0s   error=build failed: couldn't find main file:
                              stat cli: no such file or directory
                              target=linux_arm64_v8.0
```

## Root cause

Commit aa3f2f20 (`QD-12546 Switch to a single goreleaser configuration`) consolidated three per-product `.goreleaser.yaml` files into one root-level file with explicit `main: ./cli | ./clang | ./cdnet`. It updated the GitHub Actions workflow to invoke goreleaser from the repo root (which is why `main` nightlies still succeed), but only half-updated `.teamcity/cli/GoReleaser.kt`:

1. "Run GoReleaser" step still sets `workingDir = wd` (= `"cli"`). GoReleaser resolves `main` relative to invocation CWD, so `./cli` from CWD `cli/` looks for `cli/cli` → does not exist.
2. `artifactRules = "${wd}/dist => ."` still points at pre-consolidation `cli/dist/` instead of the new root-level `dist/`.
3. Neither `.goreleaser.yaml` (on 261) nor the TC script has a `go generate` step — even after fixing (1) and (2), `clang` and `cdnet` builds would fail because their `//go:embed` archives (`clang/clang-tidy-*.tar.gz`, `cdnet/clt.zip`, `internal/tooling/qodana-jbrs/*.tar.gz`, `internal/tooling/libs/*.jar`) are not committed to git.

## Fix

- `.teamcity/cli/GoReleaser.kt`: drop `workingDir = wd` on the Run GoReleaser step; remove the redundant `../.goreleaser.yaml` config-detection block and unused `$PREFIX` variable; drop `--config $GORELEASER_CONFIG` (goreleaser auto-discovers `.goreleaser.yaml` in CWD); change `artifactRules` to `dist => .`.
- `.goreleaser.yaml`: add `pre: - cmd: go generate -v ./<id>/... ./internal/...` hook to each of the three builds, mirroring the pattern on `main`.

## Out of scope (tracked separately)

- GoReleaser version bump v2.14.3 → v2.15.4.
- Migration of deprecated keys: `archives.builds` → `archives.ids`, `nfpms.builds` → `nfpms.ids`, `brews` → `homebrew_casks`.
- Same latent bug on `main` (not triggered today because `main` nightlies run on GitHub Actions). Will forward-port in a separate PR once this one is green.

## Test plan

- [x] Local reproduction from `cli/` CWD at commit 2f48558 reproduces the exact failure.
- [x] After fix, `goreleaser build --snapshot --clean --single-target --id cli` from repo root succeeds (128MB qodana binary produced at `dist/darwin_arm64/cli_darwin_arm64_v8.0/qodana`).
- [ ] TeamCity `StaticAnalysis_Cli_Releasecli` on this PR's branch progresses past "building binaries" and uploads `dist/upload/qodana_<os>_<arch>[.exe]` artifacts.
- [ ] TC DSL loader parses the edited Kotlin without errors.