### PR TITLE
:bug: QD-14452 Fix go-generate pre-commit hook in linked git worktrees

### DIFF
--- a/internal/tooling/scripts/build-qodana-jbr.go
+++ b/internal/tooling/scripts/build-qodana-jbr.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -568,7 +569,18 @@ func writeFile(path string, content string) {
 // Path helpers ================================================================================
 
 func findRepoRoot() string {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	// In a linked git worktree, `git commit` exports an absolute GIT_DIR into
+	// the pre-commit hook environment. Once `go generate` cd's into a
+	// subdirectory, that GIT_DIR combined with the missing GIT_WORK_TREE
+	// makes `git rev-parse --show-toplevel` return cwd instead of the
+	// worktree root (documented git behavior — see "The Repository" env vars
+	// in `git help`). Drop GIT_DIR from the subprocess env so git rediscovers
+	// the repo from cwd.
+	cmd.Env = slices.DeleteFunc(os.Environ(), func(e string) bool {
+		return strings.HasPrefix(e, "GIT_DIR=")
+	})
+	out, err := cmd.Output()
 	if err != nil {
 		log.Fatalf("Cannot determine repo root: git rev-parse --show-toplevel failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

Fix for [QD-14452](https://youtrack.jetbrains.com/issue/QD-14452): the `go-generate` pre-commit hook fails during `git commit` from a secondary git worktree. Surgical change to `findRepoRoot` in `internal/tooling/scripts/build-qodana-jbr.go`: drop `GIT_DIR` from the subprocess env of `git rev-parse --show-toplevel` so git rediscovers the repo from cwd.

## Why

When `git commit` runs in a linked worktree, it exports absolute `GIT_DIR` into the hook environment but not `GIT_WORK_TREE` (git's convention is "cwd == work tree" at hook start). The moment `go generate` cd's into `internal/tooling/`, that invariant breaks and git's documented fallback kicks in: with `GIT_DIR` set explicitly and no `GIT_WORK_TREE` / `core.worktree`, `git rev-parse --show-toplevel` returns cwd instead of the worktree root. `findRepoRoot` then resolves a doubled path like `.../internal/tooling/internal/tooling/libs` and the hook exits 1.

Dropping `GIT_DIR` from the subprocess env forces git into its normal discovery path (walk up from cwd for `.git`), which works correctly regardless of worktree location. The change is scoped to the one `exec.Command` — no process-level env mutation, no new helper, no new package.

## Prior reports

- pre-commit [#2295](https://github.com/pre-commit/pre-commit/issues/2295) / [#1972](https://github.com/pre-commit/pre-commit/issues/1972) — identical symptom, upstream declined to fix. Maintainer: *"not really [planning to fix] — I don't use the feature."*
- prek inherits the same behavior for user hooks ([prek #1354](https://github.com/j178/prek/issues/1354)) — switching hook managers wouldn't help.

## Test plan

- [x] Reproduced the bug locally before the fix: `GIT_DIR=/…/.git/worktrees/<name> git rev-parse --show-toplevel` from a subdirectory of a linked worktree returns cwd.
- [x] Verified `env -u GIT_DIR git rev-parse --show-toplevel` from the same cwd returns the correct worktree root.
- [x] `go test ./internal/tooling/...` passes.
- [x] `pre-commit run --all-files` passes all three hooks (`go-generate`, `golangci-lint-full`, `go vet`).
- [x] Real `git commit` under `pre-commit install` hook from this worktree passes (the commit in this PR is itself the proof — the pre-commit hook fired during commit and `go-generate` passed).
- [ ] CI green.