### PR TITLE
:bricks: QD-14442 Run GoReleaser from repo root in TeamCity Release pipeline

### DIFF
--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -49,7 +49,7 @@ class GoReleaser(
     name = "${releaseType.name} qodana-$wd"
     description = "${releaseType.name} $arguments build of qodana-$wd for ($CLI_GITHUB_REPO_URL/$branch)"
     maxRunningBuildsPerBranch = if (releaseType != ReleaseType.Snapshot) "*:1" else "*:0"
-    artifactRules = "${wd}/dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
+    artifactRules = "dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
 
     if (buildPattern.isNotEmpty()) {
         buildNumberPattern = buildPattern
@@ -96,35 +96,9 @@ class GoReleaser(
         }
         script {
             name = "Run GoReleaser"
-            workingDir = wd
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
                     set -e
-
-                    # download required dependencies
-                    (
-                        DIR_NAME="${'$'}(basename "${'$'}PWD")"
-                        if [ "${'$'}DIR_NAME" = "cli" ] || [ "${'$'}DIR_NAME" = "clang" ] || [ "${'$'}DIR_NAME" = "cdnet" ]; then
-                            cd ..
-                        fi
-                        # 253
-                        if [ -d "./tooling" ]; then
-                            go generate ./tooling
-                        fi
-                        # main
-                        if [ -d "./internal/tooling" ]; then
-                            go generate ./internal/tooling
-                        fi
-                    )
-
-                    # run goreleaser
-                    if [ -f "../.goreleaser.yaml" ]; then
-                        GORELEASER_CONFIG="../.goreleaser.yaml"
-                        PREFIX=".."
-                    else
-                        GORELEASER_CONFIG=".goreleaser.yaml"
-                        PREFIX="."
-                    fi
 
                     ARCH=${'$'}(uname -m)
                     case ${'$'}ARCH in
@@ -142,37 +116,13 @@ class GoReleaser(
                     mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
                     chmod +x /usr/local/bin/codesign
 
-                    goreleaser release --config ${'$'}GORELEASER_CONFIG --clean ${arguments.joinToString(" ")}
+                    goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """
                     set -e
 
-                    # download required dependencies
-                    (
-                        DIR_NAME="${'$'}(basename "${'$'}PWD")"
-                        if [ "${'$'}DIR_NAME" = "cli" ] || [ "${'$'}DIR_NAME" = "clang" ] || [ "${'$'}DIR_NAME" = "cdnet" ]; then
-                            cd ..
-                        fi
-                        # 253
-                        if [ -d "./tooling" ]; then
-                            go generate ./tooling
-                        fi
-                        # main
-                        if [ -d "./internal/tooling" ]; then
-                            go generate ./internal/tooling
-                        fi
-                    )
-
-                    if [ -f "../.goreleaser.yaml" ]; then
-                        GORELEASER_CONFIG="../.goreleaser.yaml"
-                        PREFIX=".."
-                    else
-                        GORELEASER_CONFIG=".goreleaser.yaml"
-                        PREFIX="."
-                    fi
-
-                    goreleaser release --config ${'$'}GORELEASER_CONFIG --clean ${arguments.joinToString(" ")}
+                    goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             }
 


### PR DESCRIPTION
Forward-port of the same fix landed on branch 261 in #933. Same root cause, but with zero user-facing impact on `main` today because main's nightlies run on GitHub Actions (which already invokes goreleaser from the repo root); the TeamCity Release pipeline is only exercised when someone cuts a release branch. This PR removes that latent trap.

## Changes

Only `.teamcity/cli/GoReleaser.kt` (3 insertions, 53 deletions):

- Drop `workingDir = wd` on the "Run GoReleaser" step so goreleaser runs from the repo root. `main: ./cli | ./clang | ./cdnet` then resolves correctly (the active bug on 261).
- Drop the `if [ -f "../.goreleaser.yaml" ] ...` detection block and unused `$PREFIX` variable in both script branches.
- Drop `--config $GORELEASER_CONFIG` from the `goreleaser release` invocation (goreleaser auto-discovers `.goreleaser.yaml` in CWD).
- Change `artifactRules = "${wd}/dist => ."` to `artifactRules = "dist => ."` — goreleaser now writes to the repo-root `dist/`.
- Delete the "download required dependencies" subshell block (`( cd .. ; go generate ./internal/tooling )`) at the top of both script branches. `main`'s `.goreleaser.yaml` already has `pre: go generate -v ./<id>/... ./internal/...` hooks on every build that cover this, and the subshell's legacy `./tooling` (branch 253) code path is dead on main.

No change to `.goreleaser.yaml` — the required `pre:` hooks are already present.

## Links

- Related PR on branch 261: #933 (green)
- YouTrack: [QD-14442](https://youtrack.jetbrains.com/issue/QD-14442)

## Test plan

- [x] Branch 261 equivalent fix (PR #933) CI green end-to-end; GoReleaser (build), Lint, Qodana, CodeQL, Test × 5 all pass.
- [x] Local diff on main is 3 lines added, 53 lines removed — verified scope matches intent (no `.goreleaser.yaml` change).
- [ ] CI on this PR green.
- [ ] TC DSL loader parses the edited Kotlin without errors (verified by next `main` nightly run).
- [ ] No change in behaviour of the `main` GitHub Actions nightly (still invokes goreleaser from repo root with `--id cli`).