### PR TITLE
:bug: QD-14481 Drop broken GORELEASER_CURRENT_TAG override in TC Releasecli script

### DIFF
--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -142,7 +142,6 @@ class GoReleaser(
                     mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
                     chmod +x /usr/local/bin/codesign
 
-                    export GORELEASER_CURRENT_TAG=${'$'}(git describe --tags ${'$'}(git rev-list --tags --max-count=1))
                     goreleaser release --config ${'$'}GORELEASER_CONFIG --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
@@ -173,7 +172,6 @@ class GoReleaser(
                         PREFIX="."
                     fi
 
-                    export GORELEASER_CURRENT_TAG=${'$'}(git describe --tags ${'$'}(git rev-list --tags --max-count=1))
                     goreleaser release --config ${'$'}GORELEASER_CONFIG --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             }


### PR DESCRIPTION
## Summary

- Removes a forced `GORELEASER_CURRENT_TAG = $(git describe --tags $(git rev-list --tags --max-count=1))` from both `scriptContent` blocks in `.teamcity/cli/GoReleaser.kt`.
- `git rev-list --tags --max-count=1` returns the repo-wide latest tag **by commit date**, not one reachable from HEAD. Once `main`'s `v2026.2-nightly` overtook every tag reachable from `261`, every `Releasecli` triggered on `261` failed with `git tag v2026.2-nightly was not made against commit ...`.
- Goreleaser's built-in tag detection handles all three build modes correctly without the override: `Releasecli` uses `git describe --tags --exact-match HEAD`; `Nightlyclimain` auto-creates a tag from the `.goreleaser.yaml` `nightly` block; snapshot synthesizes one from `snapshot.version_template`. `.goreleaser.yaml: git.ignore_tags: [nightly, 'v*-nightly']` keeps nightly tags out of goreleaser's `previous_tag` walk on main.

## Failing build + YT links

- Failed build: [StaticAnalysis_Cli_Releasecli #934379076](https://buildserver.labs.intellij.net/buildConfiguration/StaticAnalysis_Cli_Releasecli/934379076) — Ivan's `v2026.1.2` release attempt.
- QD-14481 — this fix.
- QD-14482 — architectural follow-up (make the release pipeline branch-aware; same shell pattern also lives in `ultimate-teamcity-config/.teamcity/src/qodana/GoReleaser.kt`).

## Test plan

- [ ] TC validates the Kotlin DSL on this PR (CI must be green).
- [ ] After merge: retrigger `Releasecli` on `origin/261` HEAD (`00ab9082`, already tagged `v2026.1.2`). Expected: goreleaser `git state` shows `current_tag=v2026.1.2`, proceeds past "validating git state", and actually publishes `v2026.1.2`.
- [ ] After merge: confirm next `Nightlyclimain` run (GitHub-Actions-scheduled) completes — same file edited, but nightly path doesn't read the env var.
- [ ] Before approving: confirm in TC UI that `StaticAnalysis_Cli` Versioned Settings is pinned to `refs/heads/main` (this PR's "main only" scope is contingent on that).