### PR TITLE
:bug: QD-14483 Serialize go-generate downloads before goreleaser's parallel pre-hooks

### DIFF
--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -116,6 +116,10 @@ class GoReleaser(
                     mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
                     chmod +x /usr/local/bin/codesign
 
+                    # Serialize tooling downloads before goreleaser's per-target pre-hooks race on shared .part files (QD-14483)
+                    if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
+                    if [ -d ./tooling ]; then go generate ./tooling; fi
+
                     goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {


### PR DESCRIPTION
## Summary

Re-adds a single upfront `go generate ./internal/tooling` step in the TC `Run GoReleaser` script, before `goreleaser release`. Unblocks `Releasecli` on `261` after PR #935 exposed a latent race in 261's JBR downloader.

## What happened

Before PR #935, the TC script ran `go generate ./internal/tooling` once, serially, *before* invoking goreleaser. That upfront step populated `internal/tooling/qodana-jbrs/*/*.tar.gz` and `internal/tooling/libs/*.jar`. When goreleaser then ran its parallel per-target pre-hooks (`go generate -v ./cli/... ./internal/...` × 6 cli targets, plus clang/cdnet), the re-triggered `./internal/...` generators hit their skip-check branches (file present, size matches) and no-op'd.

PR #935 removed that upfront step, assuming the per-target pre-hooks would cover it. They do, but with concurrency — ~4 pre-hook processes at once. Branch `261`'s [`internal/tooling/scripts/download-qodana-jbr.go`](https://github.com/JetBrains/qodana-cli/blob/261/internal/tooling/scripts/download-qodana-jbr.go) uses a shared `destPath + ".part"` temp file with `os.Create` + `os.Rename` and no flock/uuid. First renamer wins; later renamers see no `.part` and fail with `rename ... no such file or directory` — exactly the failure in [build #37](https://buildserver.labs.intellij.net/buildConfiguration/StaticAnalysis_Cli_Releasecli/934477487).

Failing line on 261:
```
⨯ release failed after 36s  error=pre hook failed: hook failed: exit status 1  cmd=go  target=linux_arm64_v8.0
│ Failed to rename qodana-jbrs/linux-arm64/qodana-jbrsdk-25.0.2-linux-aarch64-b329.66.tar.gz.part to …tar.gz: rename … no such file or directory
```

## Why this fix works

`download-qodana-jbr.go` has an existing idempotent skip check at [line 123-128](https://github.com/JetBrains/qodana-cli/blob/261/internal/tooling/scripts/download-qodana-jbr.go#L123-L128). `download-libs.go` has the same at [line 62](https://github.com/JetBrains/qodana-cli/blob/261/internal/tooling/scripts/download-libs.go#L62). After this PR's upfront invocation populates the files, every per-target pre-hook's re-run of the same scripts takes the skip branch and returns without touching `.part` or recreating the file. No downloads, no races.

Main's `internal/tooling/scripts/build-qodana-jbr.go` has its own flock-based protection (QD-14002, #880) so main nightlies via GitHub Actions were unaffected — but the TC `Releasecli` path on main would have been hit too if it were exercised; this also re-protects it.

The two legacy branches live in the check:
- `./internal/tooling` — main and 261
- `./tooling` — 253

## Left for follow-up

A proper race-safe fix in 261's `download-qodana-jbr.go` (per-process `.part` suffix or `flock` wrapper). The present PR relies on the skip-check and serial first-run; option remains open to harden 261's script structurally in a separate ticket.

## Test plan

- [ ] CI on this PR (TC Kotlin DSL validation + GHA).
- [ ] After merge: Ivan retriggers `Releasecli` on `origin/261`, HEAD `00ab9082`, tag `v2026.1.2`. Expected: serial upfront downloads complete, goreleaser's per-target pre-hooks all skip the download, release proceeds to build + publish `v2026.1.2`.
- [ ] `Nightlyclimain` path unaffected (same file edited, but `Nightlyclimain` is GitHub-Actions-triggered per settings.kts, so the TC DSL change is dormant there).

## Links

- YouTrack: [QD-14483](https://youtrack.jetbrains.com/issue/QD-14483)
- Regression trigger: #935 (QD-14442, merged earlier today)
- Related analogous fix on main's source-build path: #880 (QD-14002)