### PR TITLE
:bug: QD-14482 Make release pipeline branch-bound: tag validation gate, version reconciliation, branch-aware metadata

### DIFF
--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -106,13 +106,15 @@ class GoReleaser(
                 workingDir = wd
                 scriptContent = """
                     set -e
-                    if ! git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+                    # Only accept v-prefixed release tags (e.g. v2026.1.2, v2025.1-eap); excludes the moving
+                    # 'nightly' tag and v*-nightly forms which would otherwise match --tags --exact-match.
+                    if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
                       head=${'$'}(git rev-parse HEAD)
                       branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not tagged. Refusing to cut a release.']"
+                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
                       exit 1
                     fi
-                    tag=${'$'}(git describe --tags --exact-match HEAD)
+                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
                     ver=${'$'}{tag#v}
                     echo "##teamcity[setParameter name='release.version' value='${'$'}ver']"
                     echo "##teamcity[buildNumber '${'$'}ver.%build.counter%']"

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -47,9 +47,8 @@ class GoReleaser(
     val releaseType = ReleaseType.fromArguments(arguments)
     id("${if (releaseType.isNightlyOrRelease()) releaseType.name else "Build"}$wd$branch")
     val branchDisplay = if (branch.isEmpty()) "%teamcity.build.branch%" else branch
-    val tagSuffix = if (releaseType.isRelease()) ", tag %release.version%" else ""
     name = "${releaseType.name} qodana-$wd ($branchDisplay)"
-    description = "${releaseType.name} $arguments build of qodana-$wd (branch $branchDisplay$tagSuffix) — $CLI_GITHUB_REPO_URL/tree/$branchDisplay"
+    description = "${releaseType.name} $arguments build of qodana-$wd (branch $branchDisplay) — $CLI_GITHUB_REPO_URL/tree/$branchDisplay"
     maxRunningBuildsPerBranch = if (releaseType != ReleaseType.Snapshot) "*:1" else "*:0"
     artifactRules = "dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
 
@@ -66,11 +65,7 @@ class GoReleaser(
         password("env.SERVICE_ACCOUNT_TOKEN", CODESIGN_SERVICE_ACCOUNT_TOKEN, display = ParameterDisplay.HIDDEN)
         param("env.SERVICE_ACCOUNT_NAME", CODESIGN_SERVICE_ACCOUNT_NAME)
         password("env.GORELEASER_KEY", GORELEASER_KEY, display = ParameterDisplay.HIDDEN)
-        // release.version is set by the "Validate release tag" step's setParameter on release builds,
-        // unconditionally from the git tag (no manual override — git tag is the source of truth per QD-14482).
-        // Hidden from the Run Custom Build dialog; not in env.* namespace because VERSION reaches the
-        // container only via the explicit -e flag in useGoDevContainerDockerImage's dockerRunParameters.
-        text("release.version", "", display = ParameterDisplay.HIDDEN)
+        param("env.VERSION", "%build.number%")
         param("env.QODANA_JOB_URL", "%env.BUILD_URL%")
         param("env.GO_TESTING", "true")
         param("env.DEVICEID", "200820300000000-0000-0000-0000-000000000000")
@@ -100,35 +95,21 @@ class GoReleaser(
                 workingDir = wd
             }
         }
-        if (releaseType.isRelease()) {
-            script {
-                name = "Validate release tag"
-                workingDir = wd
-                scriptContent = """
-                    set -e
-                    # Only accept v-prefixed release tags (e.g. v2026.1.2, v2025.1-eap); excludes the moving
-                    # 'nightly' tag and v*-nightly forms which would otherwise match --tags --exact-match.
-                    if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
-                      head=${'$'}(git rev-parse HEAD)
-                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
-                      exit 1
-                    fi
-                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
-                    ver=${'$'}{tag#v}
-                    echo "##teamcity[setParameter name='release.version' value='${'$'}ver']"
-                    echo "##teamcity[buildNumber '${'$'}ver.%build.counter%']"
-                """.trimIndent()
-            }
-        }
         script {
             name = "Run GoReleaser"
-            val versionExpr = if (releaseType.isRelease()) "%release.version%" else "%build.number%"
-            val versionGuard = if (releaseType.isRelease())
-                "if [ -z \"${'$'}VERSION\" ]; then\n" +
-                "                      echo \"##teamcity[buildProblem description='QD-14482: VERSION env is empty in Run GoReleaser — setParameter from Validate release tag did not propagate.']\"\n" +
+            // Release-only prelude: validate that HEAD is on a v* tag (excluding *-nightly forms),
+            // export VERSION from the tag so goreleaser and clang/cdnet ldflags pick it up, and
+            // rewrite the TC build number to the tag. QD-14482.
+            val releaseTagInit = if (releaseType.isRelease())
+                "if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then\n" +
+                "                      head=${'$'}(git rev-parse HEAD)\n" +
+                "                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)\n" +
+                "                      echo \"##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']\"\n" +
                 "                      exit 1\n" +
-                "                    fi\n                    "
+                "                    fi\n" +
+                "                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)\n" +
+                "                    export VERSION=\"${'$'}{tag#v}\"\n" +
+                "                    echo \"##teamcity[buildNumber '${'$'}VERSION.%build.counter%']\"\n                    "
                 else ""
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
@@ -154,7 +135,7 @@ class GoReleaser(
                     if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
                     if [ -d ./tooling ]; then go generate ./tooling; fi
 
-                    ${versionGuard}goreleaser release --clean ${arguments.joinToString(" ")}
+                    ${releaseTagInit}goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """
@@ -164,7 +145,7 @@ class GoReleaser(
                 """.trimIndent()
             }
 
-            useGoDevContainerDockerImage(versionExpr)
+            useGoDevContainerDockerImage()
         }
         qodana {
             enabled = qodanaToken.isNotEmpty()
@@ -294,9 +275,9 @@ private fun getProductCode(wd: String): String {
     }
 }
 
-private fun ScriptBuildStep.useGoDevContainerDockerImage(versionExpr: String) {
+private fun ScriptBuildStep.useGoDevContainerDockerImage() {
     dockerImage = "registry.jetbrains.team/p/sa/public/godevcontainer:latest"
     dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
     dockerRunParameters =
-        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false -e VERSION=$versionExpr"
+        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false  -e VERSION=%build.number%"
 }

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -100,17 +100,17 @@ class GoReleaser(
             // Release-only prelude: validate that HEAD is on a v* tag (excluding *-nightly forms),
             // export VERSION from the tag so goreleaser and clang/cdnet ldflags pick it up, and
             // rewrite the TC build number to the tag. QD-14482.
-            val releaseTagInit = if (releaseType.isRelease())
-                "if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then\n" +
-                "                      head=${'$'}(git rev-parse HEAD)\n" +
-                "                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)\n" +
-                "                      echo \"##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']\"\n" +
-                "                      exit 1\n" +
-                "                    fi\n" +
-                "                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)\n" +
-                "                    export VERSION=\"${'$'}{tag#v}\"\n" +
-                "                    echo \"##teamcity[buildNumber '${'$'}VERSION.%build.counter%']\"\n                    "
-                else ""
+            val releaseTagInit = if (releaseType.isRelease()) """
+                if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
+                  head=${'$'}(git rev-parse HEAD)
+                  branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+                  echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
+                  exit 1
+                fi
+                tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
+                export VERSION="${'$'}{tag#v}"
+                echo "##teamcity[buildNumber '${'$'}VERSION.%build.counter%']"
+            """.replaceIndent("                    ").trimStart() else ""
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
                     set -e
@@ -135,7 +135,8 @@ class GoReleaser(
                     if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
                     if [ -d ./tooling ]; then go generate ./tooling; fi
 
-                    ${releaseTagInit}goreleaser release --clean ${arguments.joinToString(" ")}
+                    ${releaseTagInit}
+                    goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -101,7 +101,8 @@ class GoReleaser(
         script {
             name = "Run GoReleaser"
             scriptContent = """
-                set -e
+                #!/usr/bin/env bash
+                set -euo pipefail
 
                 if [ "${'$'}RELEASE_TYPE" != "snapshot" ]; then
                   # Install JetBrains codesign client

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -46,8 +46,10 @@ class GoReleaser(
     allowExternalStatus = true
     val releaseType = ReleaseType.fromArguments(arguments)
     id("${if (releaseType.isNightlyOrRelease()) releaseType.name else "Build"}$wd$branch")
-    name = "${releaseType.name} qodana-$wd"
-    description = "${releaseType.name} $arguments build of qodana-$wd for ($CLI_GITHUB_REPO_URL/$branch)"
+    val branchDisplay = if (branch.isEmpty()) "%teamcity.build.branch%" else branch
+    val tagSuffix = if (releaseType.isRelease()) ", tag %release.version%" else ""
+    name = "${releaseType.name} qodana-$wd ($branchDisplay)"
+    description = "${releaseType.name} $arguments build of qodana-$wd (branch $branchDisplay$tagSuffix) — $CLI_GITHUB_REPO_URL/tree/$branchDisplay"
     maxRunningBuildsPerBranch = if (releaseType != ReleaseType.Snapshot) "*:1" else "*:0"
     artifactRules = "dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
 
@@ -64,7 +66,11 @@ class GoReleaser(
         password("env.SERVICE_ACCOUNT_TOKEN", CODESIGN_SERVICE_ACCOUNT_TOKEN, display = ParameterDisplay.HIDDEN)
         param("env.SERVICE_ACCOUNT_NAME", CODESIGN_SERVICE_ACCOUNT_NAME)
         password("env.GORELEASER_KEY", GORELEASER_KEY, display = ParameterDisplay.HIDDEN)
-        param("env.VERSION", "%build.number%")
+        // release.version is set by the "Validate release tag" step's setParameter on release builds,
+        // unconditionally from the git tag (no manual override — git tag is the source of truth per QD-14482).
+        // Hidden from the Run Custom Build dialog; not in env.* namespace because VERSION reaches the
+        // container only via the explicit -e flag in useGoDevContainerDockerImage's dockerRunParameters.
+        text("release.version", "", display = ParameterDisplay.HIDDEN)
         param("env.QODANA_JOB_URL", "%env.BUILD_URL%")
         param("env.GO_TESTING", "true")
         param("env.DEVICEID", "200820300000000-0000-0000-0000-000000000000")
@@ -94,8 +100,34 @@ class GoReleaser(
                 workingDir = wd
             }
         }
+        if (releaseType.isRelease()) {
+            script {
+                name = "Validate release tag"
+                workingDir = wd
+                scriptContent = """
+                    set -e
+                    if ! git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+                      head=${'$'}(git rev-parse HEAD)
+                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not tagged. Refusing to cut a release.']"
+                      exit 1
+                    fi
+                    tag=${'$'}(git describe --tags --exact-match HEAD)
+                    ver=${'$'}{tag#v}
+                    echo "##teamcity[setParameter name='release.version' value='${'$'}ver']"
+                    echo "##teamcity[buildNumber '${'$'}ver.%build.counter%']"
+                """.trimIndent()
+            }
+        }
         script {
             name = "Run GoReleaser"
+            val versionExpr = if (releaseType.isRelease()) "%release.version%" else "%build.number%"
+            val versionGuard = if (releaseType.isRelease())
+                "if [ -z \"${'$'}VERSION\" ]; then\n" +
+                "                      echo \"##teamcity[buildProblem description='QD-14482: VERSION env is empty in Run GoReleaser — setParameter from Validate release tag did not propagate.']\"\n" +
+                "                      exit 1\n" +
+                "                    fi\n                    "
+                else ""
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
                     set -e
@@ -120,7 +152,7 @@ class GoReleaser(
                     if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
                     if [ -d ./tooling ]; then go generate ./tooling; fi
 
-                    goreleaser release --clean ${arguments.joinToString(" ")}
+                    ${versionGuard}goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """
@@ -130,7 +162,7 @@ class GoReleaser(
                 """.trimIndent()
             }
 
-            useGoDevContainerDockerImage()
+            useGoDevContainerDockerImage(versionExpr)
         }
         qodana {
             enabled = qodanaToken.isNotEmpty()
@@ -260,9 +292,9 @@ private fun getProductCode(wd: String): String {
     }
 }
 
-private fun ScriptBuildStep.useGoDevContainerDockerImage() {
+private fun ScriptBuildStep.useGoDevContainerDockerImage(versionExpr: String) {
     dockerImage = "registry.jetbrains.team/p/sa/public/godevcontainer:latest"
     dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
     dockerRunParameters =
-        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false  -e VERSION=%build.number%"
+        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false -e VERSION=$versionExpr"
 }

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -66,6 +66,9 @@ class GoReleaser(
         param("env.SERVICE_ACCOUNT_NAME", CODESIGN_SERVICE_ACCOUNT_NAME)
         password("env.GORELEASER_KEY", GORELEASER_KEY, display = ParameterDisplay.HIDDEN)
         param("env.VERSION", "%build.number%")
+        // Drives the runtime branches inside Run GoReleaser (snapshot / nightly / release). Hidden because
+        // it's intrinsic to the build configuration — never user-tweakable.
+        text("env.RELEASE_TYPE", releaseType.name.lowercase(), display = ParameterDisplay.HIDDEN)
         param("env.QODANA_JOB_URL", "%env.BUILD_URL%")
         param("env.GO_TESTING", "true")
         param("env.DEVICEID", "200820300000000-0000-0000-0000-000000000000")
@@ -97,54 +100,47 @@ class GoReleaser(
         }
         script {
             name = "Run GoReleaser"
-            // Release-only prelude: validate that HEAD is on a v* tag (excluding *-nightly forms),
-            // export VERSION from the tag so goreleaser and clang/cdnet ldflags pick it up, and
-            // rewrite the TC build number to the tag. QD-14482.
-            val releaseTagInit = if (releaseType.isRelease()) """
-                if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
-                  head=${'$'}(git rev-parse HEAD)
-                  branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-                  echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
-                  exit 1
+            scriptContent = """
+                set -e
+
+                if [ "${'$'}RELEASE_TYPE" != "snapshot" ]; then
+                  # Install JetBrains codesign client
+                  ARCH=${'$'}(uname -m)
+                  case ${'$'}ARCH in
+                      x86_64) ARCH_SUFFIX="amd64" ;;
+                      aarch64|arm64) ARCH_SUFFIX="arm64" ;;
+                      *) echo "Unsupported architecture: ${'$'}ARCH"; exit 1 ;;
+                  esac
+                  CODESIGN_BIN="codesign-client-linux-${'$'}ARCH_SUFFIX"
+                  curl -fsSL -o /tmp/${'$'}CODESIGN_BIN https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN
+                  curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256 https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256
+                  curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256.asc https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256.asc
+                  curl -fsSL https://download-cdn.jetbrains.com/KEYS | gpg --import -
+                  gpg --batch --verify /tmp/${'$'}CODESIGN_BIN.sha256.asc /tmp/${'$'}CODESIGN_BIN.sha256
+                  (cd /tmp && sha256sum -c ${'$'}CODESIGN_BIN.sha256)
+                  mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
+                  chmod +x /usr/local/bin/codesign
+
+                  # QD-14483: serialize tooling downloads before goreleaser's per-target pre-hooks race on shared .part files
+                  if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
+                  if [ -d ./tooling ]; then go generate ./tooling; fi
                 fi
-                tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
-                export VERSION="${'$'}{tag#v}"
-                echo "##teamcity[buildNumber '${'$'}VERSION.%build.counter%']"
-            """.replaceIndent("                    ").trimStart() else ""
-            scriptContent = if (releaseType.isNightlyOrRelease()) {
-                """
-                    set -e
 
-                    ARCH=${'$'}(uname -m)
-                    case ${'$'}ARCH in
-                        x86_64) ARCH_SUFFIX="amd64" ;;
-                        aarch64|arm64) ARCH_SUFFIX="arm64" ;;
-                        *) echo "Unsupported architecture: ${'$'}ARCH"; exit 1 ;;
-                    esac
-                    CODESIGN_BIN="codesign-client-linux-${'$'}ARCH_SUFFIX"
-                    curl -fsSL -o /tmp/${'$'}CODESIGN_BIN https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN
-                    curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256 https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256
-                    curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256.asc https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256.asc
-                    curl -fsSL https://download-cdn.jetbrains.com/KEYS | gpg --import -
-                    gpg --batch --verify /tmp/${'$'}CODESIGN_BIN.sha256.asc /tmp/${'$'}CODESIGN_BIN.sha256
-                    (cd /tmp && sha256sum -c ${'$'}CODESIGN_BIN.sha256)
-                    mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
-                    chmod +x /usr/local/bin/codesign
+                if [ "${'$'}RELEASE_TYPE" = "release" ]; then
+                  # QD-14482: enforce a v* release tag at HEAD (excludes the moving 'nightly' tag and v*-nightly forms)
+                  if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
+                    head=${'$'}(git rev-parse HEAD)
+                    branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+                    echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
+                    exit 1
+                  fi
+                  tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
+                  export VERSION="${'$'}{tag#v}"
+                  echo "##teamcity[buildNumber '${'$'}VERSION.%build.counter%']"
+                fi
 
-                    # Serialize tooling downloads before goreleaser's per-target pre-hooks race on shared .part files (QD-14483)
-                    if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
-                    if [ -d ./tooling ]; then go generate ./tooling; fi
-
-                    ${releaseTagInit}
-                    goreleaser release --clean ${arguments.joinToString(" ")}
-                """.trimIndent()
-            } else {
-                """
-                    set -e
-
-                    goreleaser release --clean ${arguments.joinToString(" ")}
-                """.trimIndent()
-            }
+                goreleaser release --clean ${arguments.joinToString(" ")}
+            """.trimIndent()
 
             useGoDevContainerDockerImage()
         }


### PR DESCRIPTION
## QD-14482: make `StaticAnalysis_Cli_Releasecli` branch-bound

Acceptance criteria:
1. **HEAD-reachable release tag only** — `git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD`. Accepts `v2026.1.2` / `v2025.1-eap`; rejects bare `nightly`, `v2026.1-nightly`, `v2026.2-nightly` (all of which exist in the repo today).
2. **Fail fast on untagged HEAD** — `##teamcity[buildProblem ...]` + `exit 1` before goreleaser runs.
3. **Version reconciliation** — `VERSION` is derived from the tag and `export`ed before `goreleaser release`. clang/cdnet ldflags (`{{ .Env.VERSION }}`) and the cli ldflag (`{{ .Version }}`, from goreleaser's own tag detection) now both resolve to the same value.
4. **Branch in build name/description** — `%teamcity.build.branch%` interpolation. Build number is rewritten to `<tag>.<counter>` via service message on release builds.

## Design

One hidden TC param drives the runtime branches:

```kotlin
text("env.RELEASE_TYPE", releaseType.name.lowercase(), display = ParameterDisplay.HIDDEN)
```

`Run GoReleaser`'s `scriptContent` is a single unified bash script (no Kotlin `if/else` branching the content). Two runtime guards keyed off `$RELEASE_TYPE`:

- `if [ "$RELEASE_TYPE" != "snapshot" ]` — codesign-client download + QD-14483 tooling-download serialization
- `if [ "$RELEASE_TYPE" = "release" ]` — `git describe` tag gate, `export VERSION`, `##teamcity[buildNumber ...]`

Header: `#!/usr/bin/env bash` + `set -euo pipefail` — matches the convention from TC's auto-generated `denestFileArtifacts()` runner. The shebang is required because `pipefail` is a bash extension; without it, TC defaults to `/bin/sh` (dash on Debian, ash on Alpine).

`useGoDevContainerDockerImage()` stays no-arg; `dockerRunParameters` unchanged.

## Verification

`mvn -B teamcity-configs:generate` → BUILD SUCCESS. Generated `Releasecli.xml` and `Nightlyclimain.xml` share **identical** `script.content`; only the `env.RELEASE_TYPE` param value differs (`release` vs `nightly`), driving the runtime branches.

## What this PR doesn't do

- 261 forward-port: tracked in #944.
- 253: out of scope (not actively releasing).

## Test plan

- [ ] CI is green (mvn compile + DSL generate)
- [ ] After merge: TC retrigger `Releasecli` on `main` without tagging HEAD → fails fast on the tag gate
- [ ] Tag `main` with `v0.0.0-test`, retrigger → all three binaries (`qodana`, `qodana-clang`, `qodana-cdnet`) report `version 0.0.0-test`; build number renders `0.0.0-test.<counter>`; description shows `branch main`. Remove the test tag afterwards
- [ ] TC retrigger `Nightlyclimain` on `main` → tag gate skipped; existing nightly flow runs unchanged