### PR TITLE
QD-14481/14483/14482 Forward-port release pipeline fixes from main to 261

### DIFF
--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -105,13 +105,15 @@ class GoReleaser(
                 workingDir = wd
                 scriptContent = """
                     set -e
-                    if ! git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+                    # Only accept v-prefixed release tags (e.g. v2026.1.2, v2025.1-eap); excludes the moving
+                    # 'nightly' tag and v*-nightly forms which would otherwise match --tags --exact-match.
+                    if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
                       head=${'$'}(git rev-parse HEAD)
                       branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not tagged. Refusing to cut a release.']"
+                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
                       exit 1
                     fi
-                    tag=${'$'}(git describe --tags --exact-match HEAD)
+                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
                     ver=${'$'}{tag#v}
                     echo "##teamcity[setParameter name='release.version' value='${'$'}ver']"
                     echo "##teamcity[buildNumber '${'$'}ver.%build.counter%']"

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -99,17 +99,17 @@ class GoReleaser(
             // Release-only prelude: validate that HEAD is on a v* tag (excluding *-nightly forms),
             // export VERSION from the tag so goreleaser and clang/cdnet ldflags pick it up, and
             // rewrite the TC build number to the tag. QD-14482.
-            val releaseTagInit = if (releaseType.isRelease())
-                "if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then\n" +
-                "                      head=${'$'}(git rev-parse HEAD)\n" +
-                "                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)\n" +
-                "                      echo \"##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']\"\n" +
-                "                      exit 1\n" +
-                "                    fi\n" +
-                "                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)\n" +
-                "                    export VERSION=\"${'$'}{tag#v}\"\n" +
-                "                    echo \"##teamcity[buildNumber '${'$'}VERSION.%build.counter%']\"\n                    "
-                else ""
+            val releaseTagInit = if (releaseType.isRelease()) """
+                if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
+                  head=${'$'}(git rev-parse HEAD)
+                  branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+                  echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
+                  exit 1
+                fi
+                tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
+                export VERSION="${'$'}{tag#v}"
+                echo "##teamcity[buildNumber '${'$'}VERSION.%build.counter%']"
+            """.replaceIndent("                    ").trimStart() else ""
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
                     set -e
@@ -134,7 +134,8 @@ class GoReleaser(
                     if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
                     if [ -d ./tooling ]; then go generate ./tooling; fi
 
-                    ${releaseTagInit}goreleaser release --clean ${arguments.joinToString(" ")}
+                    ${releaseTagInit}
+                    goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -100,7 +100,8 @@ class GoReleaser(
         script {
             name = "Run GoReleaser"
             scriptContent = """
-                set -e
+                #!/usr/bin/env bash
+                set -euo pipefail
 
                 if [ "${'$'}RELEASE_TYPE" != "snapshot" ]; then
                   # Install JetBrains codesign client

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -45,8 +45,10 @@ class GoReleaser(
     allowExternalStatus = true
     val releaseType = ReleaseType.fromArguments(arguments)
     id("${if (releaseType.isNightlyOrRelease()) releaseType.name else "Build"}$wd$branch")
-    name = "${releaseType.name} qodana-$wd"
-    description = "${releaseType.name} $arguments build of qodana-$wd for ($CLI_GITHUB_REPO_URL/$branch)"
+    val branchDisplay = if (branch.isEmpty()) "%teamcity.build.branch%" else branch
+    val tagSuffix = if (releaseType.isRelease()) ", tag %release.version%" else ""
+    name = "${releaseType.name} qodana-$wd ($branchDisplay)"
+    description = "${releaseType.name} $arguments build of qodana-$wd (branch $branchDisplay$tagSuffix) — $CLI_GITHUB_REPO_URL/tree/$branchDisplay"
     maxRunningBuildsPerBranch = if (releaseType != ReleaseType.Snapshot) "*:1" else "*:0"
     artifactRules = "dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
 
@@ -63,7 +65,11 @@ class GoReleaser(
         password("env.SERVICE_ACCOUNT_TOKEN", CODESIGN_SERVICE_ACCOUNT_TOKEN, display = ParameterDisplay.HIDDEN)
         param("env.SERVICE_ACCOUNT_NAME", CODESIGN_SERVICE_ACCOUNT_NAME)
         password("env.GORELEASER_KEY", GORELEASER_KEY, display = ParameterDisplay.HIDDEN)
-        param("env.VERSION", "%build.number%")
+        // release.version is set by the "Validate release tag" step's setParameter on release builds,
+        // unconditionally from the git tag (no manual override — git tag is the source of truth per QD-14482).
+        // Hidden from the Run Custom Build dialog; not in env.* namespace because VERSION reaches the
+        // container only via the explicit -e flag in useGoDevContainerDockerImage's dockerRunParameters.
+        text("release.version", "", display = ParameterDisplay.HIDDEN)
         param("env.QODANA_JOB_URL", "%env.BUILD_URL%")
         param("env.GO_TESTING", "true")
         param("env.DEVICEID", "200820300000000-0000-0000-0000-000000000000")
@@ -93,8 +99,34 @@ class GoReleaser(
                 workingDir = wd
             }
         }
+        if (releaseType.isRelease()) {
+            script {
+                name = "Validate release tag"
+                workingDir = wd
+                scriptContent = """
+                    set -e
+                    if ! git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+                      head=${'$'}(git rev-parse HEAD)
+                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not tagged. Refusing to cut a release.']"
+                      exit 1
+                    fi
+                    tag=${'$'}(git describe --tags --exact-match HEAD)
+                    ver=${'$'}{tag#v}
+                    echo "##teamcity[setParameter name='release.version' value='${'$'}ver']"
+                    echo "##teamcity[buildNumber '${'$'}ver.%build.counter%']"
+                """.trimIndent()
+            }
+        }
         script {
             name = "Run GoReleaser"
+            val versionExpr = if (releaseType.isRelease()) "%release.version%" else "%build.number%"
+            val versionGuard = if (releaseType.isRelease())
+                "if [ -z \"${'$'}VERSION\" ]; then\n" +
+                "                      echo \"##teamcity[buildProblem description='QD-14482: VERSION env is empty in Run GoReleaser — setParameter from Validate release tag did not propagate.']\"\n" +
+                "                      exit 1\n" +
+                "                    fi\n                    "
+                else ""
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
                     set -e
@@ -115,19 +147,21 @@ class GoReleaser(
                     mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
                     chmod +x /usr/local/bin/codesign
 
-                    export GORELEASER_CURRENT_TAG=${'$'}(git describe --tags ${'$'}(git rev-list --tags --max-count=1))
-                    goreleaser release --clean ${arguments.joinToString(" ")}
+                    # Serialize tooling downloads before goreleaser's per-target pre-hooks race on shared .part files (QD-14483)
+                    if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
+                    if [ -d ./tooling ]; then go generate ./tooling; fi
+
+                    ${versionGuard}goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """
                     set -e
 
-                    export GORELEASER_CURRENT_TAG=${'$'}(git describe --tags ${'$'}(git rev-list --tags --max-count=1))
                     goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             }
 
-            useGoDevContainerDockerImage()
+            useGoDevContainerDockerImage(versionExpr)
         }
         qodana {
             enabled = qodanaToken.isNotEmpty()
@@ -248,9 +282,9 @@ private fun getProductCode(wd: String): String {
     }
 }
 
-private fun ScriptBuildStep.useGoDevContainerDockerImage() {
+private fun ScriptBuildStep.useGoDevContainerDockerImage(versionExpr: String) {
     dockerImage = "registry.jetbrains.team/p/sa/public/godevcontainer:latest"
     dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
     dockerRunParameters =
-        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false  -e VERSION=%build.number%"
+        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false -e VERSION=$versionExpr"
 }

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -65,6 +65,9 @@ class GoReleaser(
         param("env.SERVICE_ACCOUNT_NAME", CODESIGN_SERVICE_ACCOUNT_NAME)
         password("env.GORELEASER_KEY", GORELEASER_KEY, display = ParameterDisplay.HIDDEN)
         param("env.VERSION", "%build.number%")
+        // Drives the runtime branches inside Run GoReleaser (snapshot / nightly / release). Hidden because
+        // it's intrinsic to the build configuration — never user-tweakable.
+        text("env.RELEASE_TYPE", releaseType.name.lowercase(), display = ParameterDisplay.HIDDEN)
         param("env.QODANA_JOB_URL", "%env.BUILD_URL%")
         param("env.GO_TESTING", "true")
         param("env.DEVICEID", "200820300000000-0000-0000-0000-000000000000")
@@ -96,54 +99,47 @@ class GoReleaser(
         }
         script {
             name = "Run GoReleaser"
-            // Release-only prelude: validate that HEAD is on a v* tag (excluding *-nightly forms),
-            // export VERSION from the tag so goreleaser and clang/cdnet ldflags pick it up, and
-            // rewrite the TC build number to the tag. QD-14482.
-            val releaseTagInit = if (releaseType.isRelease()) """
-                if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
-                  head=${'$'}(git rev-parse HEAD)
-                  branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-                  echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
-                  exit 1
+            scriptContent = """
+                set -e
+
+                if [ "${'$'}RELEASE_TYPE" != "snapshot" ]; then
+                  # Install JetBrains codesign client
+                  ARCH=${'$'}(uname -m)
+                  case ${'$'}ARCH in
+                      x86_64) ARCH_SUFFIX="amd64" ;;
+                      aarch64|arm64) ARCH_SUFFIX="arm64" ;;
+                      *) echo "Unsupported architecture: ${'$'}ARCH"; exit 1 ;;
+                  esac
+                  CODESIGN_BIN="codesign-client-linux-${'$'}ARCH_SUFFIX"
+                  curl -fsSL -o /tmp/${'$'}CODESIGN_BIN https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN
+                  curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256 https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256
+                  curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256.asc https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256.asc
+                  curl -fsSL https://download-cdn.jetbrains.com/KEYS | gpg --import -
+                  gpg --batch --verify /tmp/${'$'}CODESIGN_BIN.sha256.asc /tmp/${'$'}CODESIGN_BIN.sha256
+                  (cd /tmp && sha256sum -c ${'$'}CODESIGN_BIN.sha256)
+                  mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
+                  chmod +x /usr/local/bin/codesign
+
+                  # QD-14483: serialize tooling downloads before goreleaser's per-target pre-hooks race on shared .part files
+                  if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
+                  if [ -d ./tooling ]; then go generate ./tooling; fi
                 fi
-                tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
-                export VERSION="${'$'}{tag#v}"
-                echo "##teamcity[buildNumber '${'$'}VERSION.%build.counter%']"
-            """.replaceIndent("                    ").trimStart() else ""
-            scriptContent = if (releaseType.isNightlyOrRelease()) {
-                """
-                    set -e
 
-                    ARCH=${'$'}(uname -m)
-                    case ${'$'}ARCH in
-                        x86_64) ARCH_SUFFIX="amd64" ;;
-                        aarch64|arm64) ARCH_SUFFIX="arm64" ;;
-                        *) echo "Unsupported architecture: ${'$'}ARCH"; exit 1 ;;
-                    esac
-                    CODESIGN_BIN="codesign-client-linux-${'$'}ARCH_SUFFIX"
-                    curl -fsSL -o /tmp/${'$'}CODESIGN_BIN https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN
-                    curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256 https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256
-                    curl -fsSL -o /tmp/${'$'}CODESIGN_BIN.sha256.asc https://codesign-distribution.labs.jb.gg/${'$'}CODESIGN_BIN.sha256.asc
-                    curl -fsSL https://download-cdn.jetbrains.com/KEYS | gpg --import -
-                    gpg --batch --verify /tmp/${'$'}CODESIGN_BIN.sha256.asc /tmp/${'$'}CODESIGN_BIN.sha256
-                    (cd /tmp && sha256sum -c ${'$'}CODESIGN_BIN.sha256)
-                    mv /tmp/${'$'}CODESIGN_BIN /usr/local/bin/codesign
-                    chmod +x /usr/local/bin/codesign
+                if [ "${'$'}RELEASE_TYPE" = "release" ]; then
+                  # QD-14482: enforce a v* release tag at HEAD (excludes the moving 'nightly' tag and v*-nightly forms)
+                  if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
+                    head=${'$'}(git rev-parse HEAD)
+                    branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+                    echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
+                    exit 1
+                  fi
+                  tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
+                  export VERSION="${'$'}{tag#v}"
+                  echo "##teamcity[buildNumber '${'$'}VERSION.%build.counter%']"
+                fi
 
-                    # Serialize tooling downloads before goreleaser's per-target pre-hooks race on shared .part files (QD-14483)
-                    if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
-                    if [ -d ./tooling ]; then go generate ./tooling; fi
-
-                    ${releaseTagInit}
-                    goreleaser release --clean ${arguments.joinToString(" ")}
-                """.trimIndent()
-            } else {
-                """
-                    set -e
-
-                    goreleaser release --clean ${arguments.joinToString(" ")}
-                """.trimIndent()
-            }
+                goreleaser release --clean ${arguments.joinToString(" ")}
+            """.trimIndent()
 
             useGoDevContainerDockerImage()
         }

--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -46,9 +46,8 @@ class GoReleaser(
     val releaseType = ReleaseType.fromArguments(arguments)
     id("${if (releaseType.isNightlyOrRelease()) releaseType.name else "Build"}$wd$branch")
     val branchDisplay = if (branch.isEmpty()) "%teamcity.build.branch%" else branch
-    val tagSuffix = if (releaseType.isRelease()) ", tag %release.version%" else ""
     name = "${releaseType.name} qodana-$wd ($branchDisplay)"
-    description = "${releaseType.name} $arguments build of qodana-$wd (branch $branchDisplay$tagSuffix) — $CLI_GITHUB_REPO_URL/tree/$branchDisplay"
+    description = "${releaseType.name} $arguments build of qodana-$wd (branch $branchDisplay) — $CLI_GITHUB_REPO_URL/tree/$branchDisplay"
     maxRunningBuildsPerBranch = if (releaseType != ReleaseType.Snapshot) "*:1" else "*:0"
     artifactRules = "dist => ." + if (!isCli) "\n\n +:*-third-party-libraries.json" else ""
 
@@ -65,11 +64,7 @@ class GoReleaser(
         password("env.SERVICE_ACCOUNT_TOKEN", CODESIGN_SERVICE_ACCOUNT_TOKEN, display = ParameterDisplay.HIDDEN)
         param("env.SERVICE_ACCOUNT_NAME", CODESIGN_SERVICE_ACCOUNT_NAME)
         password("env.GORELEASER_KEY", GORELEASER_KEY, display = ParameterDisplay.HIDDEN)
-        // release.version is set by the "Validate release tag" step's setParameter on release builds,
-        // unconditionally from the git tag (no manual override — git tag is the source of truth per QD-14482).
-        // Hidden from the Run Custom Build dialog; not in env.* namespace because VERSION reaches the
-        // container only via the explicit -e flag in useGoDevContainerDockerImage's dockerRunParameters.
-        text("release.version", "", display = ParameterDisplay.HIDDEN)
+        param("env.VERSION", "%build.number%")
         param("env.QODANA_JOB_URL", "%env.BUILD_URL%")
         param("env.GO_TESTING", "true")
         param("env.DEVICEID", "200820300000000-0000-0000-0000-000000000000")
@@ -99,35 +94,21 @@ class GoReleaser(
                 workingDir = wd
             }
         }
-        if (releaseType.isRelease()) {
-            script {
-                name = "Validate release tag"
-                workingDir = wd
-                scriptContent = """
-                    set -e
-                    # Only accept v-prefixed release tags (e.g. v2026.1.2, v2025.1-eap); excludes the moving
-                    # 'nightly' tag and v*-nightly forms which would otherwise match --tags --exact-match.
-                    if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then
-                      head=${'$'}(git rev-parse HEAD)
-                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-                      echo "##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']"
-                      exit 1
-                    fi
-                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)
-                    ver=${'$'}{tag#v}
-                    echo "##teamcity[setParameter name='release.version' value='${'$'}ver']"
-                    echo "##teamcity[buildNumber '${'$'}ver.%build.counter%']"
-                """.trimIndent()
-            }
-        }
         script {
             name = "Run GoReleaser"
-            val versionExpr = if (releaseType.isRelease()) "%release.version%" else "%build.number%"
-            val versionGuard = if (releaseType.isRelease())
-                "if [ -z \"${'$'}VERSION\" ]; then\n" +
-                "                      echo \"##teamcity[buildProblem description='QD-14482: VERSION env is empty in Run GoReleaser — setParameter from Validate release tag did not propagate.']\"\n" +
+            // Release-only prelude: validate that HEAD is on a v* tag (excluding *-nightly forms),
+            // export VERSION from the tag so goreleaser and clang/cdnet ldflags pick it up, and
+            // rewrite the TC build number to the tag. QD-14482.
+            val releaseTagInit = if (releaseType.isRelease())
+                "if ! git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD >/dev/null 2>&1; then\n" +
+                "                      head=${'$'}(git rev-parse HEAD)\n" +
+                "                      branch=${'$'}(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)\n" +
+                "                      echo \"##teamcity[buildProblem description='QD-14482: HEAD ${'$'}head on branch ${'$'}branch is not on a release tag (v*, excluding *-nightly). Refusing to cut a release.']\"\n" +
                 "                      exit 1\n" +
-                "                    fi\n                    "
+                "                    fi\n" +
+                "                    tag=${'$'}(git describe --tags --exact-match --match 'v*' --exclude '*-nightly' HEAD)\n" +
+                "                    export VERSION=\"${'$'}{tag#v}\"\n" +
+                "                    echo \"##teamcity[buildNumber '${'$'}VERSION.%build.counter%']\"\n                    "
                 else ""
             scriptContent = if (releaseType.isNightlyOrRelease()) {
                 """
@@ -153,7 +134,7 @@ class GoReleaser(
                     if [ -d ./internal/tooling ]; then go generate ./internal/tooling; fi
                     if [ -d ./tooling ]; then go generate ./tooling; fi
 
-                    ${versionGuard}goreleaser release --clean ${arguments.joinToString(" ")}
+                    ${releaseTagInit}goreleaser release --clean ${arguments.joinToString(" ")}
                 """.trimIndent()
             } else {
                 """
@@ -163,7 +144,7 @@ class GoReleaser(
                 """.trimIndent()
             }
 
-            useGoDevContainerDockerImage(versionExpr)
+            useGoDevContainerDockerImage()
         }
         qodana {
             enabled = qodanaToken.isNotEmpty()
@@ -284,9 +265,9 @@ private fun getProductCode(wd: String): String {
     }
 }
 
-private fun ScriptBuildStep.useGoDevContainerDockerImage(versionExpr: String) {
+private fun ScriptBuildStep.useGoDevContainerDockerImage() {
     dockerImage = "registry.jetbrains.team/p/sa/public/godevcontainer:latest"
     dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
     dockerRunParameters =
-        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false -e VERSION=$versionExpr"
+        "--privileged -v /var/run/docker.sock:/var/run/docker.sock -e GOFLAGS=-buildvcs=false  -e VERSION=%build.number%"
 }


### PR DESCRIPTION
## Forward-port of three release-pipeline fixes from `main` to `261`

All three were already merged on `main` after the QD-14442/14481/14483 chain unblocked `Releasecli` on 2026-04-27. TC Versioned Settings is pinned to `main`, so 261's `.teamcity/cli/GoReleaser.kt` is dead w.r.t. the live build — this PR keeps the branches consistent, avoiding the kind of trap that produced QD-14481 in the first place (where 261's diverged copy made the failure mode harder to spot).

### Tickets

- **QD-14481** — remove broken `GORELEASER_CURRENT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))` override (picked repo-wide latest tag by date, not HEAD-reachable). Reference main commit: `be4caeee`.
- **QD-14483** — add upfront `go generate ./internal/tooling` serialization so goreleaser's parallel pre-hooks don't race on shared `.part` files. The race in 261's `download-qodana-jbr.go` itself is tracked in QD-14618. Reference main commit: `a51a33db`.
- **QD-14482** — branch-bound release pipeline. See #943 for the full design.

## Design

Same shape as #943: one hidden `env.RELEASE_TYPE` TC param drives a unified `Run GoReleaser` bash script with `#!/usr/bin/env bash` + `set -euo pipefail`. Two runtime guards:

- `if [ "$RELEASE_TYPE" != "snapshot" ]` — codesign + QD-14483 serialization
- `if [ "$RELEASE_TYPE" = "release" ]` — v* tag gate (`--match 'v*' --exclude '*-nightly'`), `export VERSION`, `##teamcity[buildNumber ...]`

## Verification

`mvn -B teamcity-configs:generate` → BUILD SUCCESS. Generated XML on 261 mirrors #943.

## Test plan

- [ ] CI is green
- [ ] After merge: TC retrigger `Releasecli` on `261` (HEAD = `00ab9082`, tagged `v2026.1.2`) → gate passes; build number `2026.1.2.<counter>`; description shows `branch 261`; produces only the `qodana` binary (clang/cdnet skipped per 261's `.goreleaser.yaml`); `./qodana -v` → `qodana version 2026.1.2`
- [ ] `Nightlyclimain` on `261` → tag gate skipped; succeeds