### PR TITLE
:wrench: QD-14619 Make qodana-cdnet use release builds instead of EAP-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,8 @@ brew install cmake dotnet openjdk@21
 Inside 3rd party linters docker image a different qodana-cli executable is used. To build it:
 1. `cd` into the 3rd party linter directory (e.g., `cdnet` or `clang`)
 2. Ensure dependencies are downloaded (see above) and run `go generate`
-3. Change the `buildDateStr` variable in [main.go](cdnet/main.go) to a more recent date (e.g., update it from "2023-12-05T10:52:23Z" to today's date in the same format) to avoid EAP expiration errors
-4. Build the executable: `env GOOS=linux CGO_ENABLED=0 go build -o qd-custom`
-5. To replace the executable in docker image, see `'Patching' an existing Qodana image` section below. Note that the `qodana-cdnet` image has qodana executable in `/opt/qodana/qodana` path
+3. Build the executable: `env GOOS=linux CGO_ENABLED=0 go build -o qd-custom`
+4. To replace the executable in docker image, see `'Patching' an existing Qodana image` section below. Note that the `qodana-cdnet` image has qodana executable in `/opt/qodana/qodana` path
 
 ## Working with Docker images
 

--- a/cdnet/cdnet_test.go
+++ b/cdnet/cdnet_test.go
@@ -49,7 +49,7 @@ func TestLinterRun(t *testing.T) {
 		LinterPresentableName: product.DotNetCommunityLinter.PresentableName,
 		LinterName:            product.DotNetCommunityLinter.Name,
 		LinterVersion:         version,
-		IsEap:                 true,
+		IsEap:                 product.DotNetCommunityLinter.EapOnly,
 	}
 
 	command := platform.NewThirdPartyScanCommand(CdnetLinter{}, linterInfo)

--- a/cdnet/main.go
+++ b/cdnet/main.go
@@ -20,16 +20,15 @@ import (
 	"os"
 
 	"github.com/JetBrains/qodana-cli/internal/platform/process"
+	"github.com/JetBrains/qodana-cli/internal/platform/product"
 )
 
 var InterruptChannel chan os.Signal
 var version = "2023.3"
 var buildDateStr = "2023-12-05T10:52:23Z"
 
-//var isEap = true
-
 // noinspection GoUnusedFunction
 func main() {
 	process.Init()
-	Execute(version, buildDateStr, true)
+	Execute(version, buildDateStr, product.DotNetCommunityLinter.EapOnly)
 }

--- a/internal/platform/product/product.go
+++ b/internal/platform/product/product.go
@@ -211,7 +211,7 @@ var (
 		SupportNative:   false,
 		IsPaid:          false,
 		SupportFixes:    false,
-		EapOnly:         true,
+		EapOnly:         false,
 	}
 
 	ClangLinter = Linter{


### PR DESCRIPTION
## Summary
- Changed `EapOnly: false` for `DotNetCommunityLinter` in CLI
- CLI will now pull release images `jetbrains/qodana-cdnet:X.Y.Z` instead of `jetbrains/qodana-cdnet:X.Y.Z-eap`

## Related
- Issue: https://youtrack.jetbrains.com/issue/QD-14619
- TeamCity config change: Already done in ultimate-teamcity-config

## Changes
- `internal/platform/product/product.go:214` - Set `EapOnly: false` for `DotNetCommunityLinter`

## Test plan
- [ ] Verify CLI pulls correct image version for qodana-cdnet
- [ ] Run integration tests for qodana-cdnet linter