### PR TITLE
:wrench: QD-14640 Add qodana-lsp to GitHub App scoped token repositories

### DIFF
--- a/.teamcity/cli/GoReleaser.kt
+++ b/.teamcity/cli/GoReleaser.kt
@@ -235,6 +235,7 @@ class GoReleaser(
                 scoop-utils
                 homebrew-utils
                 qodana-action
+                qodana-lsp
             """.trimIndent()
         }
     }


### PR DESCRIPTION
## Summary
- Added `qodana-lsp` to the GitHub App scoped token repository list in TeamCity configuration

## Changes
- `.teamcity/cli/GoReleaser.kt:238` - added `qodana-lsp` to targetRepositories

## Why
This enables the GitHub token to access `qodana-lsp` repository for future automated PR creation in post-release workflow.

## Related
- Issue: https://youtrack.jetbrains.com/issue/QD-14640

## Test plan
- [ ] Verify TeamCity configuration builds successfully
- [ ] After merge, token should have access to qodana-lsp repository