### PR TITLE
:sparkles: QD-14520 Add qodana-lsp job to post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -38,6 +38,38 @@ jobs:
           gh pr create --repo jetbrains/qodana-action --base main --head next --title ":arrow_up: Update \`qodana\` to the \`${VERSION}\`" --body "This automated PR updates \`qodana\` to the latest version. Please review and merge it if everything is fine."
         env:
           GITHUB_TOKEN: ${{ secrets.GH_JETBRAINS_PAT }}
+  qodana-lsp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
+        with:
+          repository: 'jetbrains/qodana-lsp'
+          token: ${{ secrets.GH_JETBRAINS_PAT }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Upgrade and send PR
+        if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
+        run: |
+          node scripts/update-cli.js
+          npm ci
+          npm run build
+          git config user.name qodana-bot
+          git config user.email qodana-support@jetbrains.com
+          git checkout -b bump-cli-version
+          git add .
+          VERSION="${{ github.event.release.name || github.event.inputs.release_name }}"
+          git commit -m ":arrow_up: Update \`qodana\` to \`${VERSION}\`"
+          git push origin bump-cli-version --force
+          gh pr create --repo jetbrains/qodana-lsp --base main --head bump-cli-version --title ":arrow_up: Update \`qodana\` to the \`${VERSION}\`" --body "This automated PR updates \`qodana\` to the latest version. Please review and merge it if everything is fine."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_JETBRAINS_PAT }}
   winget:
     runs-on: ubuntu-latest
     if: (github.event.release.name || github.event.inputs.release_name) != 'nightly' && github.repository == 'jetbrains/qodana-cli'


### PR DESCRIPTION
## Summary
- Added new `qodana-lsp` job to automatically create PRs in qodana-lsp repository after CLI release
- Uses `scripts/update-cli.js` which already exists in qodana-lsp repository
- Creates PRs in `bump-cli-version` branch for better clarity

## Changes
- `.github/workflows/post-release.yml` - added `qodana-lsp` job after `github-actions`

## How it works
1. Checks out `jetbrains/qodana-lsp` repository
2. Runs `node scripts/update-cli.js` to update CLI version and checksums
3. Installs dependencies and builds the project
4. Creates and pushes `bump-cli-version` branch
5. Creates PR with updated CLI version

## Related
- Issue: https://youtrack.jetbrains.com/issue/QD-14520
- Main PR: #950
- Depends on: #949 (merged - GitHub App token access to qodana-lsp)

## Test plan
- [ ] Verify workflow syntax is correct
- [ ] Test on next CLI release from 261 branch