### PR TITLE
:wrench: QD-14619 Make qodana-clang use release builds instead of EAP-only

### DIFF
--- a/clang/clang_test.go
+++ b/clang/clang_test.go
@@ -39,7 +39,7 @@ func TestLinterRun(t *testing.T) {
 		LinterName:            product.ClangLinter.Name,
 		LinterPresentableName: product.ClangLinter.PresentableName,
 		LinterVersion:         version,
-		IsEap:                 true,
+		IsEap:                 product.ClangLinter.EapOnly,
 	}
 
 	command := platform.NewThirdPartyScanCommand(ClangLinter{}, linterInfo)

--- a/clang/main.go
+++ b/clang/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/JetBrains/qodana-cli/internal/platform/process"
+	"github.com/JetBrains/qodana-cli/internal/platform/product"
 )
 
 var InterruptChannel chan os.Signal
@@ -13,5 +14,5 @@ var buildDateStr = "2024-04-05T10:52:23Z"
 // noinspection GoUnusedFunction
 func main() {
 	process.Init()
-	Execute(version, buildDateStr, true)
+	Execute(version, buildDateStr, product.ClangLinter.EapOnly)
 }

--- a/internal/platform/product/product.go
+++ b/internal/platform/product/product.go
@@ -222,7 +222,7 @@ var (
 		SupportNative:   false,
 		IsPaid:          false,
 		SupportFixes:    false,
-		EapOnly:         true,
+		EapOnly:         false,
 	}
 
 	// AllLinters Order is important for detection


### PR DESCRIPTION
## Summary
- Changed `EapOnly: false` for `ClangLinter` in CLI
- CLI will now pull release images `jetbrains/qodana-clang:X.Y.Z` instead of `jetbrains/qodana-clang:X.Y.Z-eap`

## Related
- Issue: https://youtrack.jetbrains.com/issue/QD-14619
- Main PR: #954
- Similar PR for cdnet: #947

## Changes
- `internal/platform/product/product.go:225` - Set `EapOnly: false` for `ClangLinter`
- `clang/main.go:17` - Use `product.ClangLinter.EapOnly` instead of hardcoded `true`
- `clang/clang_test.go:225` - Use `product.ClangLinter.EapOnly` instead of hardcoded `true`

All isEap/EapOnly values now reference a single source of truth.

## Test plan
- [ ] Verify CLI pulls correct image version for qodana-clang
- [ ] Run integration tests for qodana-clang linter