### PR TITLE
:bug: QD-14674 Install script: default OUT_DIR to ~/.local/bin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,14 +177,22 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           NIGHTLY_VERSION: ${{ steps.nightly.outputs.version }}
 
-#  install-script-check:
-#    strategy:
-#        fail-fast: false
-#        matrix:
-#            os: [ubuntu-latest, macos-latest]
-#    runs-on: ${{ matrix.os }}
-#    steps:
-#      - uses: actions/checkout@v6
-#      - run: |
-#          ./install
-#          ./install nightly
+  install-script-check:
+    name: "Install script (${{ matrix.os }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pinned version (default OUT_DIR)
+        run: |
+          ./install v2026.1.1
+          test -x "$HOME/.local/bin/qodana"
+          "$HOME/.local/bin/qodana" --version
+      - name: Install pinned version with explicit override
+        run: |
+          tmp=$(mktemp -d)
+          ./install v2026.1.1 "$tmp"
+          test -x "$tmp/qodana"

--- a/install
+++ b/install
@@ -18,7 +18,12 @@
 
 RELEASE=${1}
 TMP_DIR="/tmp/tmpinstalldir"
-OUT_DIR=${2:-"/usr/local/bin"}
+OUT_DIR=${2:-"$HOME/.local/bin"}
+OUT_DIR="${OUT_DIR%/}"
+if [ -z "${HOME:-}" ] && [ -z "${2:-}" ]; then
+  echo "Error: HOME is not set; pass an explicit install directory as the 2nd arg" >&2
+  exit 1
+fi
 check_mark="\033[1;32m✓\033[0m"
 
 
@@ -37,12 +42,13 @@ echo -e '
 '
 
 echo -e "
-👋 This script will download Qodana CLI to \033[4m/usr/local/bin/qodana\033[0m
-   If you get 'permission denied' error:
-   - Specify other dir and version: \033[4mcurl -fsSL https://jb.gg/qodana-cli/install | bash -s -- v2023.2.8 $HOME/.local/bin\033[0m
-   - Or change the owner of $OUT_DIR to your user
-   If you get API rate limit exceeded error:
-   - Specify the version, so the script does not query GitHub API: \033[4mcurl -fsSL https://jb.gg/qodana-cli/install | bash -s -- v2023.2.8 \033[0m
+👋 This script will install Qodana CLI to \033[4m$OUT_DIR/qodana\033[0m
+   To install to a different directory (e.g. for a system-wide install),
+   pass it as the second argument (system-wide dirs may require sudo):
+   - \033[4mcurl -fsSL https://jb.gg/qodana-cli/install | bash -s -- v2026.1.1 /usr/local/bin\033[0m
+   If you get an API rate limit error:
+   - Specify the version so the script does not query GitHub API:
+     \033[4mcurl -fsSL https://jb.gg/qodana-cli/install | bash -s -- v2023.2.8\033[0m
 "
 set -e
 
@@ -70,7 +76,8 @@ function install {
 	INSECURE="false"
 	#bash check
 	[ ! "$BASH_VERSION" ] && fail "Please use bash instead"
-	[ ! -d $OUT_DIR ] && fail "output directory missing: $OUT_DIR"
+	mkdir -p "$OUT_DIR" 2>/dev/null || fail "could not create output directory: $OUT_DIR"
+	[ -w "$OUT_DIR" ] || fail "output directory is not writable: $OUT_DIR (re-run with sudo or pass a writable directory)"
 	#dependency check, assume we are a standard POSIX machine
 	which find > /dev/null || fail "find not installed"
 	which xargs > /dev/null || fail "xargs not installed"
@@ -161,6 +168,15 @@ function install {
 	mv "$TMP_BIN" "$OUT_DIR"/$PROG || fail "mv failed" #FINAL STEP!
 	echo -e "$ qodana --help " && "$OUT_DIR/$PROG" --help
 	echo -e "${check_mark} Installed at $OUT_DIR/$PROG"
+	case ":$PATH:" in
+	  *":$OUT_DIR:"*) ;;
+	  *)
+	    echo -e "\n\033[1;33m⚠ $OUT_DIR is not in your PATH.\033[0m"
+	    echo -e "  Add this line to your shell config (e.g. ~/.zshrc, ~/.bashrc, ~/.profile):"
+	    echo -e "    \033[0;33mexport PATH=\"$OUT_DIR:\$PATH\"\033[0m"
+	    echo -e "  Then restart your shell or 'source' that file."
+	    ;;
+	esac
 	cleanup
 	header "Next steps\n"
   echo -e "‣ \033[1mInitialize Qodana in a project\033[0m"

--- a/install
+++ b/install
@@ -18,12 +18,14 @@
 
 RELEASE=${1}
 TMP_DIR="/tmp/tmpinstalldir"
-OUT_DIR=${2:-"$HOME/.local/bin"}
-OUT_DIR="${OUT_DIR%/}"
 if [ -z "${HOME:-}" ] && [ -z "${2:-}" ]; then
   echo "Error: HOME is not set; pass an explicit install directory as the 2nd arg" >&2
   exit 1
 fi
+OUT_DIR=${2:-"$HOME/.local/bin"}
+while [ "${OUT_DIR}" != "/" ] && [ "${OUT_DIR%/}" != "${OUT_DIR}" ]; do
+  OUT_DIR="${OUT_DIR%/}"
+done
 check_mark="\033[1;32m✓\033[0m"
 
 


### PR DESCRIPTION
## Summary

The advertised one-liner `curl -fsSL https://jb.gg/qodana-cli/install | bash` failed out-of-the-box for non-root users — the install script defaulted `OUT_DIR` to `/usr/local/bin`, which is not writable without `sudo`. This PR defaults `OUT_DIR` to `$HOME/.local/bin`, matching the convention used by `uv`, `fnm`, `rustup`, `bun`, `deno`, `nvm`, and `pnpm`.

Fixes [QD-14674](https://youtrack.jetbrains.com/issue/QD-14674).

### Changes to `install`

1. **Default `OUT_DIR=$HOME/.local/bin`** (was `/usr/local/bin`). Trailing slash stripped for stable PATH match.
2. **Guard against unset `$HOME`** — fail early with a clear message rather than silently expanding to `/.local/bin`.
3. **Rewritten intro banner** — uses `$OUT_DIR` instead of a hardcoded path; reframes the override flow around "system-wide install" rather than "permission denied recovery."
4. **Auto-create `OUT_DIR` + writability check** — replaces `[ ! -d $OUT_DIR ] && fail` with `mkdir -p` + `[ -w ]`. Fails *before* downloading 100MB+ when the dir is not writable (e.g. user passed a system path without sudo). Incidentally fixes a latent SC2086 shellcheck warning.
5. **PATH warning** — if `$OUT_DIR` is not in `$PATH` (common on macOS zsh), print a copy-pasteable `export PATH=...` line for the user's shell config. No automatic shell-rc modification.

### Changes to `.github/workflows/ci.yml`

Uncomment and harden the `install-script-check` matrix job. Runs `./install v2026.1.1` on `ubuntu-latest` and `macos-latest` (both non-root) in two scenarios: default `OUT_DIR` and explicit override. Asserts the binary lands where expected and `qodana --version` works. **This is the CI guard that would have caught the bug this PR fixes.** Pinned to an explicit version to avoid GitHub API rate-limit flakes.

## Sudo behavior

Pure default — matches uv/fnm/bun/deno/nvm/pnpm. `curl … | sudo bash` will install to `/root/.local/bin` (root's HOME), same footgun as those tools. Users who explicitly want a system-wide install must pass the directory as the 2nd positional arg: `curl … | sudo bash -s -- v2026.1.1 /usr/local/bin`.

Research of 10 popular installers confirmed: 7 of 10 (uv, fnm, bun, deno, nvm, pnpm, rustup-wrapper) do exactly this. Only starship and Homebrew handle sudo proactively.

## Backwards-compatibility

This is a behavior change for two automation patterns:

- `curl … | bash` then invoking `qodana` expecting it on `$PATH` — `~/.local/bin` is not in `$PATH` by default on macOS zsh. The new PATH warning at the end of the install surfaces the issue.
- `curl … | sudo bash` expecting `/usr/local/bin`. Such automation must now pass `/usr/local/bin` explicitly.

## Test plan

- [x] Local: `shellcheck install` (no new findings vs `main` baseline; the pre-existing SC2086 on line 73 is fixed in passing)
- [x] Local: default-path install in throwaway `$HOME` → binary present, `--version` works, PATH warning fires
- [x] Local: explicit-override install → binary at custom dir
- [x] Local: unwritable explicit dir (`/opt/qodana-readonly-test`) → fails fast before download
- [x] Local: unset `HOME` + no override → fails with "HOME is not set" message
- [x] Local: unset `HOME` + override → succeeds
- [ ] CI: revived `install-script-check` matrix job on ubuntu-latest + macos-latest

## Out of scope (separate PRs)

Two pre-existing unrelated bugs in `install` surfaced during review but are *not* touched by this PR to keep scope focused:

- `cleanup()` is a no-op (`echo rm -rf $TMP_DIR > /dev/null` instead of `rm -rf "$TMP_DIR"`).
- `\033[0\n` SGR escape on line 136 is missing the terminating `m`.

The README's `./install nightly` snippet is also broken (no `nightly` release tag exists at `https://github.com/JetBrains/qodana-cli/releases/`) — separate issue.