### PR TITLE
fix: QD-14520 Remove build step from qodana-lsp workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -58,16 +58,14 @@ jobs:
         if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
         run: |
           node scripts/update-cli.js
-          npm ci
-          npm run build
           git config user.name qodana-bot
           git config user.email qodana-support@jetbrains.com
           git checkout -b bump-cli-version
           git add .
           VERSION="${{ github.event.release.name || github.event.inputs.release_name }}"
-          git commit -m ":arrow_up: Update \`qodana\` to \`${VERSION}\`"
+          git commit -m "chore: update CLI to ${VERSION}"
           git push origin bump-cli-version --force
-          gh pr create --repo jetbrains/qodana-lsp --base main --head bump-cli-version --title ":arrow_up: Update \`qodana\` to the \`${VERSION}\`" --body "This automated PR updates \`qodana\` to the latest version. Please review and merge it if everything is fine."
+          gh pr create --repo jetbrains/qodana-lsp --base main --head bump-cli-version --title "chore: update CLI to ${VERSION}" --body "This automated PR updates \`qodana\` to the latest version. Please review and merge it if everything is fine."
         env:
           GITHUB_TOKEN: ${{ secrets.GH_JETBRAINS_PAT }}
   winget:


### PR DESCRIPTION
## Problem
The qodana-lsp job in post-release workflow was failing with:
```
npm error The `npm ci` command can only install with an existing package-lock.json
```

## Root Cause
The qodana-lsp repository has `package.json` in `vscode/qodana/` directory, not in the root. Running `npm ci` and `npm run build` in the root directory fails.

## Solution
Removed `npm ci` and `npm run build` steps from the workflow. For qodana-lsp, only updating `cli.json` is needed - the build happens automatically during the release process (when tag is pushed).

## Changes
- Removed unnecessary build steps
- Changed commit message format to `chore: update CLI to ${VERSION}` to match qodana-lsp conventions

Related: https://youtrack.jetbrains.com/issue/QD-14520