### PR TITLE
QD-14804 Make chmod-based fs tests fail loudly when DAC is bypassed

### DIFF
--- a/internal/foundation/fs/canonical_execonly_test.go
+++ b/internal/foundation/fs/canonical_execonly_test.go
@@ -12,18 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// requireExecOnlyEnforced verifies that chmodding `dir` to 0o111 (execute-only)
-// actually denies ReadDir. Root or CAP_DAC_READ_SEARCH bypass DAC and make these
-// tests meaningless — surface that loudly with an actionable opt-out hint.
-func requireExecOnlyEnforced(t *testing.T, dir string) {
-	t.Helper()
-	if _, err := os.ReadDir(dir); err == nil {
-		t.Fatalf("environment does not enforce 0o111 directory perms "+
-			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
-			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
-	}
-}
-
 func TestCanonical_ExecOnlyDir(t *testing.T) {
 	needs.Need(t, needs.NonRoot)
 
@@ -34,7 +22,14 @@ func TestCanonical_ExecOnlyDir(t *testing.T) {
 
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
-	requireExecOnlyEnforced(t, dir)
+
+	// Precondition: 0o111 must actually deny ReadDir. Root or
+	// CAP_DAC_READ_SEARCH bypass DAC; surface that loudly.
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Fatalf("environment does not enforce 0o111 directory perms "+
+			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
+			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
+	}
 
 	got, err := Canonical(filepath.Join(dir, "file"))
 	require.NoError(t, err, "Canonical must work with execute-only parent dir")
@@ -51,7 +46,12 @@ func TestWeaklyCanonical_ExecOnlyDir(t *testing.T) {
 
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
-	requireExecOnlyEnforced(t, dir)
+
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Fatalf("environment does not enforce 0o111 directory perms "+
+			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
+			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
+	}
 
 	got, err := WeaklyCanonical(filepath.Join(dir, "file"))
 	require.NoError(t, err, "WeaklyCanonical must work with execute-only parent dir")
@@ -59,8 +59,8 @@ func TestWeaklyCanonical_ExecOnlyDir(t *testing.T) {
 }
 
 func TestCanonical_ExecOnlyDirCaseNormalization(t *testing.T) {
-	skipIfCaseSensitive(t)
 	needs.Need(t, needs.NonRoot)
+	skipIfCaseSensitive(t)
 
 	tmp := canonicalTempDir(t)
 	dir := filepath.Join(tmp, "ExecOnly")
@@ -69,7 +69,12 @@ func TestCanonical_ExecOnlyDirCaseNormalization(t *testing.T) {
 
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
-	requireExecOnlyEnforced(t, dir)
+
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Fatalf("environment does not enforce 0o111 directory perms "+
+			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
+			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
+	}
 
 	// On a case-insensitive FS, asking for wrong-case "mixedcase" should
 	// still return the on-disk name "MixedCase".

--- a/internal/foundation/fs/canonical_execonly_test.go
+++ b/internal/foundation/fs/canonical_execonly_test.go
@@ -7,14 +7,25 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/JetBrains/qodana-cli/internal/testutil/needs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCanonical_ExecOnlyDir(t *testing.T) {
-	if os.Getuid() == 0 {
-		t.Skip("root bypasses permission checks")
+// requireExecOnlyEnforced verifies that chmodding `dir` to 0o111 (execute-only)
+// actually denies ReadDir. Root or CAP_DAC_READ_SEARCH bypass DAC and make these
+// tests meaningless — surface that loudly with an actionable opt-out hint.
+func requireExecOnlyEnforced(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Fatalf("environment does not enforce 0o111 directory perms "+
+			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
+			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
 	}
+}
+
+func TestCanonical_ExecOnlyDir(t *testing.T) {
+	needs.Need(t, needs.NonRoot)
 
 	tmp := canonicalTempDir(t)
 	dir := filepath.Join(tmp, "execonly")
@@ -23,6 +34,7 @@ func TestCanonical_ExecOnlyDir(t *testing.T) {
 
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	requireExecOnlyEnforced(t, dir)
 
 	got, err := Canonical(filepath.Join(dir, "file"))
 	require.NoError(t, err, "Canonical must work with execute-only parent dir")
@@ -30,9 +42,7 @@ func TestCanonical_ExecOnlyDir(t *testing.T) {
 }
 
 func TestWeaklyCanonical_ExecOnlyDir(t *testing.T) {
-	if os.Getuid() == 0 {
-		t.Skip("root bypasses permission checks")
-	}
+	needs.Need(t, needs.NonRoot)
 
 	tmp := canonicalTempDir(t)
 	dir := filepath.Join(tmp, "execonly")
@@ -41,6 +51,7 @@ func TestWeaklyCanonical_ExecOnlyDir(t *testing.T) {
 
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	requireExecOnlyEnforced(t, dir)
 
 	got, err := WeaklyCanonical(filepath.Join(dir, "file"))
 	require.NoError(t, err, "WeaklyCanonical must work with execute-only parent dir")
@@ -49,9 +60,7 @@ func TestWeaklyCanonical_ExecOnlyDir(t *testing.T) {
 
 func TestCanonical_ExecOnlyDirCaseNormalization(t *testing.T) {
 	skipIfCaseSensitive(t)
-	if os.Getuid() == 0 {
-		t.Skip("root bypasses permission checks")
-	}
+	needs.Need(t, needs.NonRoot)
 
 	tmp := canonicalTempDir(t)
 	dir := filepath.Join(tmp, "ExecOnly")
@@ -60,6 +69,7 @@ func TestCanonical_ExecOnlyDirCaseNormalization(t *testing.T) {
 
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	requireExecOnlyEnforced(t, dir)
 
 	// On a case-insensitive FS, asking for wrong-case "mixedcase" should
 	// still return the on-disk name "MixedCase".

--- a/internal/foundation/fs/canonical_execonly_test.go
+++ b/internal/foundation/fs/canonical_execonly_test.go
@@ -23,13 +23,7 @@ func TestCanonical_ExecOnlyDir(t *testing.T) {
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 
-	// Precondition: 0o111 must actually deny ReadDir. Root or
-	// CAP_DAC_READ_SEARCH bypass DAC; surface that loudly.
-	if _, err := os.ReadDir(dir); err == nil {
-		t.Fatalf("environment does not enforce 0o111 directory perms "+
-			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
-			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
-	}
+	requireReadDirDenied(t, dir)
 
 	got, err := Canonical(filepath.Join(dir, "file"))
 	require.NoError(t, err, "Canonical must work with execute-only parent dir")
@@ -47,11 +41,7 @@ func TestWeaklyCanonical_ExecOnlyDir(t *testing.T) {
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 
-	if _, err := os.ReadDir(dir); err == nil {
-		t.Fatalf("environment does not enforce 0o111 directory perms "+
-			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
-			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
-	}
+	requireReadDirDenied(t, dir)
 
 	got, err := WeaklyCanonical(filepath.Join(dir, "file"))
 	require.NoError(t, err, "WeaklyCanonical must work with execute-only parent dir")
@@ -70,11 +60,7 @@ func TestCanonical_ExecOnlyDirCaseNormalization(t *testing.T) {
 	require.NoError(t, os.Chmod(dir, 0o111))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 
-	if _, err := os.ReadDir(dir); err == nil {
-		t.Fatalf("environment does not enforce 0o111 directory perms "+
-			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
-			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
-	}
+	requireReadDirDenied(t, dir)
 
 	// On a case-insensitive FS, asking for wrong-case "mixedcase" should
 	// still return the on-disk name "MixedCase".

--- a/internal/foundation/fs/copydir_readdir_error_test.go
+++ b/internal/foundation/fs/copydir_readdir_error_test.go
@@ -1,0 +1,38 @@
+//go:build darwin || linux
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JetBrains/qodana-cli/internal/testutil/needs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyDir_ReadDirError(t *testing.T) {
+	needs.Need(t, needs.NonRoot)
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("data"), 0o644))
+
+	require.NoError(t, os.Chmod(srcDir, 0o000))
+	// Restore perms before t.TempDir's RemoveAll cleanup runs.
+	// t.Cleanup is LIFO; this runs before the TempDir cleanup registered earlier.
+	t.Cleanup(func() { _ = os.Chmod(srcDir, 0o755) })
+
+	// Precondition: chmod 0o000 must actually deny ReadDir. Root or
+	// CAP_DAC_READ_SEARCH bypass DAC and make the rest of the test
+	// meaningless — surface that loudly instead of returning a misleading
+	// "expected error got nil" later.
+	if _, err := os.ReadDir(srcDir); err == nil {
+		t.Fatalf("environment does not enforce 0o000 directory perms "+
+			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
+			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
+	}
+
+	err := CopyDir(srcDir, filepath.Join(t.TempDir(), "dst"))
+	assert.Error(t, err)
+}

--- a/internal/foundation/fs/copydir_readdir_error_test.go
+++ b/internal/foundation/fs/copydir_readdir_error_test.go
@@ -23,15 +23,7 @@ func TestCopyDir_ReadDirError(t *testing.T) {
 	// t.Cleanup is LIFO; this runs before the TempDir cleanup registered earlier.
 	t.Cleanup(func() { _ = os.Chmod(srcDir, 0o755) })
 
-	// Precondition: chmod 0o000 must actually deny ReadDir. Root or
-	// CAP_DAC_READ_SEARCH bypass DAC and make the rest of the test
-	// meaningless — surface that loudly instead of returning a misleading
-	// "expected error got nil" later.
-	if _, err := os.ReadDir(srcDir); err == nil {
-		t.Fatalf("environment does not enforce 0o000 directory perms "+
-			"(uid=%d, gid=%d); run as non-root user, or set %s=0 to skip",
-			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
-	}
+	requireReadDirDenied(t, srcDir)
 
 	err := CopyDir(srcDir, filepath.Join(t.TempDir(), "dst"))
 	assert.Error(t, err)

--- a/internal/foundation/fs/fs_test.go
+++ b/internal/foundation/fs/fs_test.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,21 +46,6 @@ func TestCopyDir(t *testing.T) {
 
 	data, _ = os.ReadFile(filepath.Join(dstDir, "copied", "subdir", "file2.txt"))
 	assert.Equal(t, "content2", string(data))
-}
-
-func TestCopyDir_ReadDirError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission-based test not reliable on Windows")
-	}
-	srcDir := t.TempDir()
-	_ = os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("data"), 0o644)
-
-	// Remove read permission so ReadDir fails.
-	assert.NoError(t, os.Chmod(srcDir, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(srcDir, 0o755) })
-
-	err := CopyDir(srcDir, filepath.Join(t.TempDir(), "dst"))
-	assert.Error(t, err)
 }
 
 func TestAppendToFile(t *testing.T) {

--- a/internal/foundation/fs/permissions_test.go
+++ b/internal/foundation/fs/permissions_test.go
@@ -1,0 +1,25 @@
+//go:build darwin || linux
+
+package fs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/JetBrains/qodana-cli/internal/testutil/needs"
+)
+
+// requireReadDirDenied asserts that the OS actually denies ReadDir on dir, which
+// the caller has just chmodded to a restrictive mode (e.g. 0o111 or 0o000).
+// Root and CAP_DAC_READ_SEARCH / CAP_DAC_OVERRIDE bypass discretionary access
+// control, so ReadDir succeeds and the chmod-based test becomes meaningless.
+// Fail loudly with an actionable hint instead of letting a later assertion fail
+// with a misleading "expected error got nil".
+func requireReadDirDenied(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Fatalf("environment does not enforce restrictive directory permissions "+
+			"(uid=%d, gid=%d); run as a non-root user, or set %s=0 to skip",
+			os.Getuid(), os.Getgid(), needs.NonRoot.EnvVar)
+	}
+}

--- a/internal/testutil/needs/needs.go
+++ b/internal/testutil/needs/needs.go
@@ -20,6 +20,7 @@ var (
 	ClangDeps      = Flag{"ClangDeps", "QT_ENABLE_CLANG_DEPS"}
 	CdnetDeps      = Flag{"CdnetDeps", "QT_ENABLE_CDNET_DEPS"}
 	CasefoldFS     = Flag{"CasefoldFS", "QT_ENABLE_CASEFOLD_FS"}
+	NonRoot        = Flag{"NonRoot", "QT_ENABLE_NON_ROOT"}
 )
 
 // Need skips the test if any of the given flags are disabled.

--- a/internal/testutil/needs/needs_test.go
+++ b/internal/testutil/needs/needs_test.go
@@ -46,3 +46,26 @@ func TestNeed_RunsWhenEnabled(t *testing.T) {
 	Need(t, f)
 	// if we reach here, Need did not skip
 }
+
+// TestFlagSpellings pins each public flag's Name and EnvVar so a typo in the
+// var declaration shows up here rather than in a downstream test that
+// silently no-ops because the env var name doesn't match what CI sets.
+func TestFlagSpellings(t *testing.T) {
+	for _, tt := range []struct {
+		got            Flag
+		wantName       string
+		wantEnvVar     string
+	}{
+		{Docker, "Docker", "QT_ENABLE_DOCKER"},
+		{ContainerTests, "ContainerTests", "QT_ENABLE_CONTAINER_TESTS"},
+		{ClangDeps, "ClangDeps", "QT_ENABLE_CLANG_DEPS"},
+		{CdnetDeps, "CdnetDeps", "QT_ENABLE_CDNET_DEPS"},
+		{CasefoldFS, "CasefoldFS", "QT_ENABLE_CASEFOLD_FS"},
+		{NonRoot, "NonRoot", "QT_ENABLE_NON_ROOT"},
+	} {
+		t.Run(tt.wantName, func(t *testing.T) {
+			assert.Equal(t, tt.wantName, tt.got.Name)
+			assert.Equal(t, tt.wantEnvVar, tt.got.EnvVar)
+		})
+	}
+}

--- a/internal/testutil/needs/needs_test.go
+++ b/internal/testutil/needs/needs_test.go
@@ -46,26 +46,3 @@ func TestNeed_RunsWhenEnabled(t *testing.T) {
 	Need(t, f)
 	// if we reach here, Need did not skip
 }
-
-// TestFlagSpellings pins each public flag's Name and EnvVar so a typo in the
-// var declaration shows up here rather than in a downstream test that
-// silently no-ops because the env var name doesn't match what CI sets.
-func TestFlagSpellings(t *testing.T) {
-	for _, tt := range []struct {
-		got            Flag
-		wantName       string
-		wantEnvVar     string
-	}{
-		{Docker, "Docker", "QT_ENABLE_DOCKER"},
-		{ContainerTests, "ContainerTests", "QT_ENABLE_CONTAINER_TESTS"},
-		{ClangDeps, "ClangDeps", "QT_ENABLE_CLANG_DEPS"},
-		{CdnetDeps, "CdnetDeps", "QT_ENABLE_CDNET_DEPS"},
-		{CasefoldFS, "CasefoldFS", "QT_ENABLE_CASEFOLD_FS"},
-		{NonRoot, "NonRoot", "QT_ENABLE_NON_ROOT"},
-	} {
-		t.Run(tt.wantName, func(t *testing.T) {
-			assert.Equal(t, tt.wantName, tt.got.Name)
-			assert.Equal(t, tt.wantEnvVar, tt.got.EnvVar)
-		})
-	}
-}


### PR DESCRIPTION
## Summary

- Adds `needs.NonRoot` flag (env var `QT_ENABLE_NON_ROOT`) matching the existing `needs.Docker`/`ContainerTests`/... pattern.
- Refactors `TestCopyDir_ReadDirError` and the three `internal/foundation/fs/canonical_execonly_test.go` tests to call `needs.Need(t, needs.NonRoot)` for opt-out, then assert their precondition (a `ReadDir` on the chmodded directory must error) and `t.Fatalf` with `uid=…, gid=…; set QT_ENABLE_NON_ROOT=0 to skip` when DAC is bypassed.
- Moves `TestCopyDir_ReadDirError` into `copydir_readdir_error_test.go` with `//go:build darwin || linux`, matching `canonical_execonly_test.go`'s layout. Drops the now-unused `runtime` import from `fs_test.go`.

## Why

[QD-14804](https://youtrack.jetbrains.com/issue/QD-14804). `ijplatform_master_TestCli` has been failing on `main` for 8 consecutive runs since May 12 ([build #245](https://buildserver.labs.intellij.net/buildConfiguration/ijplatform_master_TestCli/954395148)). Root cause: `TestCopyDir_ReadDirError` uses `os.Chmod(dir, 0o000)` to provoke a `ReadDir` failure, but the TC step runs inside `--privileged` `godevcontainer:latest` as root, which holds `CAP_DAC_READ_SEARCH` / `CAP_DAC_OVERRIDE` and bypasses the chmod. The "expected error got nil" message gave no clue why — this PR makes the failure self-diagnosing.

A companion PR on `ultimate-teamcity-config` sets `env.QT_ENABLE_NON_ROOT=0` on the `TestCli` step so the four `NonRoot` tests cleanly skip in CI today. [QD-14805](https://youtrack.jetbrains.com/issue/QD-14805) tracks switching the container to a non-root user; once that lands, the opt-out goes away.

## Test plan

- [x] Local non-root: `go test ./internal/foundation/fs/ -run 'TestCopyDir_ReadDirError|TestCanonical_ExecOnlyDir|TestWeaklyCanonical_ExecOnlyDir|TestCanonical_ExecOnlyDirCaseNormalization' -v` — all four pass.
- [x] Simulated root (via `docker run --rm -v $PWD:/src golang:1.25 go test ...`) — tests fail loudly with `environment does not enforce 0oXXX directory perms (uid=0, gid=0); run as non-root user, or set QT_ENABLE_NON_ROOT=0 to skip`.
- [x] Simulated root + `QT_ENABLE_NON_ROOT=0` — tests cleanly skip with `requires NonRoot (set QT_ENABLE_NON_ROOT=1 to enable)`.
- [x] `go test ./internal/foundation/fs/...` (full package) — all other tests pass; no regressions.
- [x] `go vet ./internal/foundation/fs/ ./internal/testutil/needs/` — clean.
- [ ] TeamCity green on `ijplatform_master_TestCli` once the companion `ultimate-teamcity-config` PR lands.