### PR TITLE
:fire: QD-14791 QD-14813 Remove implicit scan injection from CLI dispatch

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -43,124 +43,156 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestIsHelpOrVersion(t *testing.T) {
-	tests := []struct {
-		args     []string
-		expected bool
-	}{
-		{[]string{"qodana", "--help"}, true},
-		{[]string{"qodana", "-h"}, true},
-		{[]string{"qodana", "help"}, true},
-		{[]string{"qodana", "--version"}, true},
-		{[]string{"qodana", "-v"}, true},
-		{[]string{"qodana", "scan"}, false},
-		{[]string{"qodana"}, false},
-		{[]string{"qodana", "--help", "extra"}, false},
-	}
-	for _, tt := range tests {
-		if result := isHelpOrVersion(tt.args); result != tt.expected {
-			t.Errorf("isHelpOrVersion(%v) = %v, want %v", tt.args, result, tt.expected)
+// dispatchTestRoot builds a root command with stub subcommands matching what
+// InitCli registers in production. *ranCmd captures the name of whichever
+// stub's Run executed (empty if none did). The scan stub also exposes a -i
+// shorthand flag so tests can exercise scan flag parsing without pulling in
+// the real scan command's container/native machinery.
+func dispatchTestRoot() (rootCmd *cobra.Command, out *bytes.Buffer, ranCmd *string) {
+	rootCmd = newRootCommand()
+	out = &bytes.Buffer{}
+	rootCmd.SetOut(out)
+	rootCmd.SetErr(out)
+	captured := ""
+	ranCmd = &captured
+	subcommands := []string{"scan", "init", "show", "send", "pull", "view", "contributors", "cloc"}
+	for _, name := range subcommands {
+		n := name
+		stub := &cobra.Command{
+			Use: n,
+			Run: func(cmd *cobra.Command, args []string) { *ranCmd = n },
 		}
-	}
-}
-
-func TestIsCompletionRequested(t *testing.T) {
-	tests := []struct {
-		args     []string
-		expected bool
-	}{
-		{[]string{"qodana", "completion"}, true},
-		{[]string{"qodana", "completion", "bash"}, true},
-		{[]string{"qodana", "scan"}, false},
-		{[]string{"qodana"}, false},
-	}
-	for _, tt := range tests {
-		if result := isCompletionRequested(tt.args); result != tt.expected {
-			t.Errorf("isCompletionRequested(%v) = %v, want %v", tt.args, result, tt.expected)
+		if n == "scan" {
+			stub.Flags().StringP("input", "i", "", "")
 		}
+		rootCmd.AddCommand(stub)
 	}
-}
-
-func TestIsCommandRequested(t *testing.T) {
-	rootCmd := newRootCommand()
-	rootCmd.AddCommand(newScanCommand())
-	rootCmd.AddCommand(newInitCommand())
-	rootCmd.AddCommand(newPullCommand())
-	tests := []struct {
-		args     []string
-		expected string
-	}{
-		{[]string{"scan"}, "scan"},
-		{[]string{"init"}, "init"},
-		{[]string{"pull"}, "pull"},
-		{[]string{"--help"}, ""},
-		{[]string{"unknown"}, ""},
-	}
-	for _, tt := range tests {
-		if result := isCommandRequested(rootCmd.Commands(), tt.args); result != tt.expected {
-			t.Errorf("isCommandRequested(..., %v) = %v, want %v", tt.args, result, tt.expected)
-		}
-	}
-}
-
-func TestSetDefaultCommandIfNeeded(t *testing.T) {
-	tests := []struct {
-		name string
-		args []string
-	}{
-		{"no args adds scan", []string{"qodana", "-i", "."}},
-		{"help flag unchanged", []string{"qodana", "--help"}},
-		{"version flag unchanged", []string{"qodana", "-v"}},
-		{"scan command unchanged", []string{"qodana", "scan", "-i", "."}},
-		{"init command unchanged", []string{"qodana", "init"}},
-	}
-	for _, tt := range tests {
-		t.Run(
-			tt.name, func(t *testing.T) {
-				rootCmd := newRootCommand()
-				rootCmd.AddCommand(newScanCommand())
-				rootCmd.AddCommand(newInitCommand())
-				setDefaultCommandIfNeeded(rootCmd, tt.args)
-			},
-		)
-	}
+	return
 }
 
 // TestQD14791HelpCompletionDispatch regression-locks QD-14791:
 // `qodana help completion` must reach cobra's help subcommand, never scan.
 //
-// This test simulates production by invoking setDefaultCommandIfNeeded with
-// the same arg shape Execute() passes from os.Args, then running cobra
-// dispatch. On the current (pre-removal) code, the helper rewrites args to
-// ["scan", "help", "completion"] and the scan stub runs — the test fails.
-// The follow-up removal commit deletes the helper, deletes this call, and
-// the test passes against cobra-native dispatch.
+// In the commit that added this test, the body included an explicit
+// setDefaultCommandIfNeeded(...) call that demonstrated the bug (the test
+// failed because scan ran). The removal commit deleted that helper and
+// the call line; this test now lives as forward-going regression coverage
+// against cobra-native dispatch.
 func TestQD14791HelpCompletionDispatch(t *testing.T) {
-	rootCmd := newRootCommand()
-	var ranCmd string
-	for _, name := range []string{"scan", "init", "show", "send", "pull", "view", "contributors", "cloc"} {
-		n := name
-		rootCmd.AddCommand(&cobra.Command{
-			Use: n,
-			Run: func(cmd *cobra.Command, args []string) { ranCmd = n },
-		})
-	}
-
-	out := &bytes.Buffer{}
-	rootCmd.SetOut(out)
-	rootCmd.SetErr(out)
+	rootCmd, out, ranCmd := dispatchTestRoot()
 	rootCmd.SetArgs([]string{"help", "completion"})
-	setDefaultCommandIfNeeded(rootCmd, []string{"qodana", "help", "completion"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if ranCmd == "scan" {
+	if *ranCmd == "scan" {
 		t.Fatalf("scan ran for `qodana help completion`; QD-14791 regression.\nCaptured output:\n%s", out.String())
 	}
 	if !strings.Contains(out.String(), "completion") {
 		t.Fatalf("expected completion-related help text in output; got:\n%s", out.String())
 	}
+}
+
+// TestRootDispatchCompletionBash locks in the QD-9907 prior-art path:
+// `qodana completion bash` must produce a bash completion script, not a scan.
+func TestRootDispatchCompletionBash(t *testing.T) {
+	rootCmd, out, ranCmd := dispatchTestRoot()
+	rootCmd.SetArgs([]string{"completion", "bash"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if *ranCmd == "scan" {
+		t.Fatalf("scan ran for `qodana completion bash`; output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "bash completion") {
+		t.Fatalf("expected bash completion script in output; got first 200 bytes:\n%s", firstNBytes(out.String(), 200))
+	}
+}
+
+// TestRootDispatchUnknownSubcommand verifies that an unknown subcommand
+// surfaces cobra's error rather than silently injecting scan.
+func TestRootDispatchUnknownSubcommand(t *testing.T) {
+	rootCmd, _, ranCmd := dispatchTestRoot()
+	rootCmd.SetArgs([]string{"fizzbuzz"})
+	rootCmd.SilenceUsage = true
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for unknown subcommand, got nil; ranCmd=%q", *ranCmd)
+	}
+	if !strings.Contains(err.Error(), "fizzbuzz") {
+		t.Fatalf("expected error to mention `fizzbuzz`; got: %v", err)
+	}
+	if *ranCmd != "" {
+		t.Fatalf("no stub should have run for `fizzbuzz`; ran %q", *ranCmd)
+	}
+}
+
+// TestRootDispatchBareInvocation verifies that bare `qodana` shows root
+// help (matches the existing root Run callback's len(args)==0 branch).
+func TestRootDispatchBareInvocation(t *testing.T) {
+	rootCmd, out, ranCmd := dispatchTestRoot()
+	rootCmd.SetArgs([]string{})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if *ranCmd != "" {
+		t.Fatalf("no subcommand should run for bare `qodana`; ran %q", *ranCmd)
+	}
+	if !strings.Contains(out.String(), "Qodana CLI") {
+		t.Fatalf("expected root help in output; got first 200 bytes:\n%s", firstNBytes(out.String(), 200))
+	}
+}
+
+// TestRootDispatchShellCompletion covers cobra's hidden shell-completion
+// request command (called by generated completion scripts at every Tab).
+// Before scan injection was removed, `qodana __complete ""` got rewritten
+// to `qodana scan __complete ""`, silently breaking shell completion.
+func TestRootDispatchShellCompletion(t *testing.T) {
+	rootCmd, _, ranCmd := dispatchTestRoot()
+	rootCmd.SetArgs([]string{cobra.ShellCompRequestCmd, ""})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if *ranCmd == "scan" {
+		t.Fatalf("scan ran for cobra shell completion request; QD-14813 regression")
+	}
+}
+
+// TestRootDispatchScanFlagValueMatchingSubcommandName verifies cobra parses
+// `scan -i <value>` correctly when <value> happens to equal a registered
+// subcommand name. Pre-removal this was a latent foot-gun in
+// isCommandRequested (it called slices.Contains over the entire arg vector,
+// matching the flag value); post-removal that helper is gone and only
+// cobra's flag parsing decides.
+func TestRootDispatchScanFlagValueMatchingSubcommandName(t *testing.T) {
+	rootCmd, _, ranCmd := dispatchTestRoot()
+	rootCmd.SetArgs([]string{"scan", "-i", "scan"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if *ranCmd != "scan" {
+		t.Fatalf("expected scan stub to run; ran %q", *ranCmd)
+	}
+	scanCmd, _, _ := rootCmd.Find([]string{"scan"})
+	got, err := scanCmd.Flags().GetString("input")
+	if err != nil {
+		t.Fatalf("could not read --input flag: %v", err)
+	}
+	if got != "scan" {
+		t.Fatalf("expected --input value %q, got %q", "scan", got)
+	}
+}
+
+func firstNBytes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 func createProject(t *testing.T, name string) string {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -40,6 +40,7 @@ import (
 	imagetypes "github.com/docker/docker/api/types/image"
 	cp "github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func TestIsHelpOrVersion(t *testing.T) {
@@ -122,6 +123,43 @@ func TestSetDefaultCommandIfNeeded(t *testing.T) {
 				setDefaultCommandIfNeeded(rootCmd, tt.args)
 			},
 		)
+	}
+}
+
+// TestQD14791HelpCompletionDispatch regression-locks QD-14791:
+// `qodana help completion` must reach cobra's help subcommand, never scan.
+//
+// This test simulates production by invoking setDefaultCommandIfNeeded with
+// the same arg shape Execute() passes from os.Args, then running cobra
+// dispatch. On the current (pre-removal) code, the helper rewrites args to
+// ["scan", "help", "completion"] and the scan stub runs — the test fails.
+// The follow-up removal commit deletes the helper, deletes this call, and
+// the test passes against cobra-native dispatch.
+func TestQD14791HelpCompletionDispatch(t *testing.T) {
+	rootCmd := newRootCommand()
+	var ranCmd string
+	for _, name := range []string{"scan", "init", "show", "send", "pull", "view", "contributors", "cloc"} {
+		n := name
+		rootCmd.AddCommand(&cobra.Command{
+			Use: n,
+			Run: func(cmd *cobra.Command, args []string) { ranCmd = n },
+		})
+	}
+
+	out := &bytes.Buffer{}
+	rootCmd.SetOut(out)
+	rootCmd.SetErr(out)
+	rootCmd.SetArgs([]string{"help", "completion"})
+	setDefaultCommandIfNeeded(rootCmd, []string{"qodana", "help", "completion"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if ranCmd == "scan" {
+		t.Fatalf("scan ran for `qodana help completion`; QD-14791 regression.\nCaptured output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "completion") {
+		t.Fatalf("expected completion-related help text in output; got:\n%s", out.String())
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"slices"
 
 	"github.com/JetBrains/qodana-cli/internal/core"
 	"github.com/JetBrains/qodana-cli/internal/platform/msg"
@@ -29,36 +28,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-// isHelpOrVersion checks if only help was requested.
-func isHelpOrVersion(args []string) bool {
-	return len(args) == 2 && (args[1] == "--help" || args[1] == "-h" || args[1] == "help" || args[1] == "--version" || args[1] == "-v")
-}
-
-func isCompletionRequested(args []string) bool {
-	return len(args) >= 2 && args[1] == "completion"
-}
-
-// isCommandRequested checks if any command is requested.
-func isCommandRequested(commands []*cobra.Command, args []string) string {
-	for _, c := range commands {
-		if slices.Contains(args, c.Name()) {
-			return c.Name()
-		}
-	}
-	return ""
-}
-
-// setDefaultCommandIfNeeded sets default scan command if no other command is requested.
-func setDefaultCommandIfNeeded(rootCmd *cobra.Command, args []string) {
-	if !isHelpOrVersion(args) && isCommandRequested(
-		rootCmd.Commands(),
-		args[1:],
-	) == "" && !isCompletionRequested(args) {
-		newArgs := append([]string{"scan"}, args[1:]...)
-		rootCmd.SetArgs(newArgs)
-	}
-}
 
 // Execute is a main CLI entrypoint: handles user interrupt, CLI start and everything else.
 func Execute() {
@@ -70,7 +39,6 @@ func Execute() {
 		msg.DisableColor()
 	}
 
-	setDefaultCommandIfNeeded(rootCommand, os.Args)
 	if err := rootCommand.Execute(); err != nil {
 		core.CheckForUpdates(version.Version)
 		_, err = fmt.Fprintf(os.Stderr, "error running command: %s\n", err)


### PR DESCRIPTION
## What

Removes the `setDefaultCommandIfNeeded` layer in `internal/cmd/root.go` that silently rewrote `qodana <args>` to `qodana scan <args>` when args didn't match a hand-rolled list of known invocations. After this PR, cobra's standard subcommand resolution handles every invocation.

This is a deliberate, product-approved removal — broader than a narrow patch to QD-14791 alone.

## Why

The injection was added in November 2023 to make `qodana -i .` work as a shorthand for `qodana scan -i .`. It has produced a recurring class of UX bugs over 2+ years:

- **QD-9907** (2024) — `qodana completion` ran scan. Patched narrowly.
- **QD-14791** (2026) — `qodana help completion` runs scan. Same root cause as QD-9907; the 2024 patch didn't generalize. **This is the bug the PR fixes.**
- **QD-5338** (2023) — same UX class, `qodana pull` auto-promoted to scan. Won't-fix.
- Latent (unreported, fixed incidentally): cobra's hidden `__complete` / `__completeNoDesc` (used by shell completion scripts at every Tab press) were silently misrouted to scan.
- Latent (unreported, fixed incidentally): `qodana -i scan` was misread because the old `isCommandRequested` scanned the entire argv for command names.

The dispatch layer saved five keystrokes and has cost the team multiple bug reports. Time to retire it.

## Tickets

- Fixes [QD-14791](https://youtrack.jetbrains.com/issue/QD-14791) — `qodana help completion` runs scan.
- Resolves [QD-14813](https://youtrack.jetbrains.com/issue/QD-14813) — "Remove implicit scan injection from CLI dispatch". **Migration guide lives there.**

## Behavior changes (breaking)

| Invocation | Before | After |
| --- | --- | --- |
| `qodana help completion` | starts scan (QD-14791) | shows completion help |
| `qodana <Tab>` (shell completion) | silently runs scan | works correctly |
| `qodana` | starts scan in CWD | shows root help |
| `qodana -i .` | runs scan with `-i .` | error: unknown flag `-i` |
| `qodana --linter qodana-jvm` | runs scan with linter | error: unknown flag |
| `qodana scan -i .` | unchanged | unchanged |
| `qodana <known-subcommand> [args]` | unchanged | unchanged |
| `qodana -v` / `--version` / `-h` / `--help` | unchanged | unchanged |

See [QD-14813](https://youtrack.jetbrains.com/issue/QD-14813) for the full table and migration cookbook (TL;DR: anywhere you had `qodana <flags>`, write `qodana scan <flags>`).

## Diff

- `internal/cmd/root.go`: −32 lines. Deletes `isHelpOrVersion`, `isCompletionRequested`, `isCommandRequested`, `setDefaultCommandIfNeeded`, the call site in `Execute()`, and the `slices` import. `Execute()` collapses to the warning + update check + `rootCommand.Execute()`.
- `internal/cmd/cmd_test.go`: refactor. Deletes the four obsolete helper tests. Adds `dispatchTestRoot()` test helper and six dispatch tests covering the QD-14791 bug, the QD-9907 prior-art path, cobra's hidden `__complete`, bare invocation, unknown subcommand, and the latent scan flag-value collision.

## TDD trail

Two commits, deliberately structured to make TDD visible:

1. **`da649ecd`** adds `TestQD14791HelpCompletionDispatch` with an explicit `setDefaultCommandIfNeeded(...)` call that demonstrates the bug. The test fails on this commit (scan runs instead of help dispatch).
2. **`1bc21cb3`** deletes the dispatch helpers and the call site. The keystone test loses its `setDefaultCommandIfNeeded` line (now undefined) and passes against cobra-native dispatch. Adds five additional post-removal dispatch tests.

CI on commit 1 in isolation would surface the failing test (the regression the fix addresses). CI on the branch HEAD (commit 2) is green.

## Test plan

- [x] `go test ./internal/cmd/...` — all tests pass.
- [x] Build & manual smoke against the local binary, every row in the behavior table above.
- [x] CI: all 14 substantive gates green (lint, codeql, goreleaser, install scripts, test matrix across macos/ubuntu/windows × docker/podman/none).