### PR TITLE
:bricks: QD-14669 Bundle structureView, todoView and structuralSearch plugins

### DIFF
--- a/dockerfiles/jvm/included_plugins.txt
+++ b/dockerfiles/jvm/included_plugins.txt
@@ -90,3 +90,6 @@ com.intellij.hardcodedPasswords
 com.intellij.mcpServer
 org.intellij.plugins.markdown
 com.intellij.copyright
+intellij.moduleSet.plugin.structureView
+intellij.moduleSet.plugin.todoView
+intellij.moduleSet.plugin.structuralSearch


### PR DESCRIPTION
# Pull Request Details

## Description

Adds three IntelliJ module-set plugins to the JVM Docker image's bundled plugin list:

- `intellij.moduleSet.plugin.structureView`
- `intellij.moduleSet.plugin.todoView`
- `intellij.moduleSet.plugin.structuralSearch`

## Related Issue

QD-14669

## Motivation and Context

These plugins are required to be bundled into the JVM-based Qodana linter image so that the corresponding inspections and views are available at analysis time.

## How Has This Been Tested

Verified that `dockerfiles/jvm/included_plugins.txt` lists the new plugin IDs and that the file ends with a trailing newline.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.