### PR TITLE
:bricks: QD-14910: Fix Dependabot Maven directory path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,7 +125,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: maven
-    directory: /internal/tooling
+    directory: /internal/tooling/scripts
     commit-message:
       prefix: ":arrow_up: QD-12983"
     schedule:


### PR DESCRIPTION
## Problem

Dependabot stopped creating automatic PRs for Maven dependencies (intellij-report-converter, qodana-web-ui) after pom.xml was moved to scripts/ subdirectory in PR #848 (Feb 27, 2026).

## Changes

- Updated `.github/dependabot.yml` Maven directory path from `/internal/tooling` to `/internal/tooling/scripts`

## Verification

✅ All Dependabot directories verified:
- github-actions: `/` ✓
- gomod: `/` ✓
- docker: all dockerfiles directories exist ✓
- maven: `/internal/tooling/scripts/pom.xml` exists ✓

After merge, Dependabot should resume weekly checks and create PRs for new versions.

## Related

- Issue: [QD-14910](https://youtrack.jetbrains.com/issue/QD-14910)
- Broken by: PR #848 (pom.xml relocation)
- Manual updates were done in: #916, #918, #919