### PR TITLE
:bricks: QD-14910: Fix Dependabot Maven directory path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,7 +125,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: maven
-    directory: /internal/tooling
+    directory: /internal/tooling/scripts
     commit-message:
       prefix: ":arrow_up: QD-12983"
     schedule:


### PR DESCRIPTION
Fix Dependabot Maven directory path after pom.xml was moved to scripts/ subdirectory.

Related: QD-14910, main PR #966