### PR TITLE
:sparkles: QD-14956 Add bundled library versions to CLI version output

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -152,10 +152,19 @@ func TestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := fmt.Sprintf("qodana version %s\n", version.Version)
 	actual := string(out)
-	if expected != actual {
-		t.Fatalf("expected \"%s\" got \"%s\"", expected, actual)
+	// Verify that output contains expected version components
+	if !strings.Contains(actual, fmt.Sprintf("Qodana CLI (%s)", version.Version)) {
+		t.Fatalf("expected output to contain 'Qodana CLI (%s)', got \"%s\"", version.Version, actual)
+	}
+	if !strings.Contains(actual, "publisher-cli:") {
+		t.Fatalf("expected output to contain 'publisher-cli:', got \"%s\"", actual)
+	}
+	if !strings.Contains(actual, "intellij-report-converter:") {
+		t.Fatalf("expected output to contain 'intellij-report-converter:', got \"%s\"", actual)
+	}
+	if !strings.Contains(actual, "qodana-web-ui:") {
+		t.Fatalf("expected output to contain 'qodana-web-ui:', got \"%s\"", actual)
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/JetBrains/qodana-cli/internal/platform/msg"
 	"github.com/JetBrains/qodana-cli/internal/platform/qdenv"
 	"github.com/JetBrains/qodana-cli/internal/platform/version"
+	"github.com/JetBrains/qodana-cli/internal/tooling"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -116,6 +117,15 @@ func newRootCommand() *cobra.Command {
 	if err := viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level")); err != nil {
 		log.Fatal(err)
 	}
+
+	// Set custom version template with bundled library versions
+	rootCmd.SetVersionTemplate(msg.VersionString(
+		version.Version,
+		tooling.PublisherCli.GetVersion(),
+		tooling.ReportConverter.GetVersion(),
+		tooling.QodanaWebUi.GetVersion(),
+	))
+
 	return rootCmd
 }
 

--- a/internal/platform/msg/output.go
+++ b/internal/platform/msg/output.go
@@ -55,6 +55,17 @@ func InfoString(version string) string {
 	)
 }
 
+// VersionString returns version information with bundled library versions.
+func VersionString(version string, publisherVersion string, converterVersion string, webUiVersion string) string {
+	result := fmt.Sprintf("Qodana CLI (%s)\n", version)
+	result += "https://jb.gg/qodana-cli\n\n"
+	result += "Bundled libraries:\n"
+	result += fmt.Sprintf("  publisher-cli: %s\n", publisherVersion)
+	result += fmt.Sprintf("  intellij-report-converter: %s\n", converterVersion)
+	result += fmt.Sprintf("  qodana-web-ui: %s\n", webUiVersion)
+	return result
+}
+
 // IsInteractive returns true if the current execution environment is interactive (useful for colors/animations toggle).
 func IsInteractive() bool {
 	return !qdenv.IsContainer() && os.Getenv("NONINTERACTIVE") == "" && (isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))

--- a/internal/platform/msg/output_test.go
+++ b/internal/platform/msg/output_test.go
@@ -14,6 +14,14 @@ func TestInfoString(t *testing.T) {
 	assert.Contains(t, result, "https://jb.gg/qodana-cli")
 }
 
+func TestVersionString(t *testing.T) {
+	result := VersionString("1.0.0", "3.1.2", "0.12.6", "0.12.6")
+	assert.Contains(t, result, "Qodana CLI (1.0.0)")
+	assert.Contains(t, result, "publisher-cli: 3.1.2")
+	assert.Contains(t, result, "intellij-report-converter: 0.12.6")
+	assert.Contains(t, result, "qodana-web-ui: 0.12.6")
+}
+
 func TestPrimary(t *testing.T) {
 	result := Primary("Hello %s", "World")
 	assert.Equal(t, "Hello World", result)

--- a/internal/tooling/libs.go
+++ b/internal/tooling/libs.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/JetBrains/qodana-cli/internal/platform/product"
 )
@@ -46,6 +47,19 @@ func (library Library) GetLibPath(cacheDir string) string {
 	matchedFile := findLibFile(library)
 	libPath := extractLib(cacheDir, matchedFile)
 	return libPath
+}
+
+func (library Library) GetVersion() string {
+	matchedFile := findLibFile(library)
+	filename := filepath.Base(matchedFile)
+	// Remove .jar extension
+	nameWithoutExt := filename[:len(filename)-4]
+	// Split by dash and get last part (version)
+	parts := strings.Split(nameWithoutExt, "-")
+	if len(parts) >= 2 {
+		return parts[len(parts)-1]
+	}
+	return "unknown"
 }
 
 func findLibFile(library Library) string {


### PR DESCRIPTION
Display versions of bundled libraries (publisher-cli, intellij-report-converter, qodana-web-ui) in `qodana --version` output.

Relates to: https://youtrack.jetbrains.com/issue/QD-14956