### PR TITLE
QD-14979: pin dhi.io/golang base to a dlopen-safe digest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,14 @@
   "extends": [
     "config:base"
   ],
+  "hostRules": [
+    {
+      "matchHost": "dhi.io",
+      "hostType": "docker",
+      "username": "{{ secrets.DHI_USERNAME }}",
+      "password": "{{ secrets.DHI_PASSWORD }}"
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": [

--- a/dockerfiles/base/go.Dockerfile
+++ b/dockerfiles/base/go.Dockerfile
@@ -1,4 +1,7 @@
-ARG GO_TAG="1.26-debian13-dev"
+# DHI golang 1.26.3 shipped libz.so.1 built -z nodlopen (DF_1_NOOPEN), which breaks the
+# IDE JVM's runtime dlopen of libzip.so (QD-14979). Pinned to a known-good digest where
+# the flag is cleared; keep the @sha256 pin — Renovate bumps the digest, the tag stays put.
+ARG GO_TAG="1.26-debian13-dev@sha256:17e7e33c3c31ec622fe56db4e7f20babf8d4829f41a8e6657da5d06b348a5577"
 ARG NODE_TAG="22-debian13-dev"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM dhi.io/golang:$GO_TAG


### PR DESCRIPTION
Fixes [QD-14979](https://youtrack.jetbrains.com/issue/QD-14979). `qodana-go` nightlies fail to start the bundled JBR:

```
java.lang.UnsatisfiedLinkError: /opt/idea/jbr/lib/libzip.so: libz.so.1: shared object cannot be dlopen()ed
→ Error occurred during initialization of VM / Unable to load zip library
```

## Root cause

The DHI `golang:1.26.3-debian13-dev` baked into `go-base-latest` (2026-05-21) ships `libz.so.1` built `-z nodlopen` (`DF_1_NOOPEN`). The IDE launcher starts the JVM by `dlopen`-ing `libjvm`, and the JVM then `dlopen`s `libzip.so` at runtime → which pulls in `libz.so.1` → glibc refuses to `dlopen` a NOOPEN object. (Bare `bin/java` works — it loads `libz` at startup as a `DT_NEEDED`, never via `dlopen`, which is why this looked JBR-specific but is purely a base-image defect.) DHI cleared the flag in `1.26.4`; stock `debian:trixie` was never NOOPEN. The base floated silently onto the bad image because the `1.26-debian13-dev` tag was unpinned.

## Fix

- **`go.Dockerfile`** — pin `GO_TAG` to the known-good multi-arch digest (`@sha256:17e7e33c…`, NOOPEN-clear). On merge, `base.yml` rebuilds & pushes `go-base-latest` on this digest → the next `QodanaGoNightly` is green.
- **`renovate.json`** — add a `dhi.io` `hostRules` block so Renovate authenticates (read-only Docker Hub OAT) and keeps the pinned digest fresh.

## ⚠️ Before merging

Add two **repository** secrets in the Mend Developer Portal (developer.mend.io → `JetBrains/qodana-cli` → Credentials), as **plaintext**:

| Secret | Value |
| --- | --- |
| `DHI_USERNAME` | the Docker Hub **org slug** (for an OAT the username is the org name, not an account or token label) |
| `DHI_PASSWORD` | the read-only Organization Access Token (needs *Image Pull* on the `dhi.io` repos Renovate reads — at least `golang`) |

A missing secret only fails `dhi.io` auth (no repo-wide config break), but provisioning before merge means Renovate's digest-bump PRs start working immediately.

## Verified

- End-to-end IDE scan on a base built from the **exact pinned digest** → `docker run` exit 0, no `libzip` error, full analysis ran to completion.
- `renovate-config-validator` passes; `hostRules` + `{{ secrets.* }}` accepted. Renovate substitutes `{{ secrets.* }}` into `username` (confirmed from source) and digest auto-update is on by default for an already-pinned `tag@sha256` under `config:base`.
- Multi-arch verified: `sha256:17e7e33c…` is an OCI image index covering `linux/amd64` + `linux/arm64`.

## Out of scope / follow-ups

- Other DHI bases (jvm, python, cpp, rust, void, dotnet, js, php, ruby) stay on rolling tags — same NOOPEN-class risk. The host-level `hostRules` already fixes their Renovate `no-result` lookups as a side effect.
- Pre-existing: `config:base` is deprecated (→ `config:recommended`); a CI `renovate-config-validator` step could be added.
