### PR TITLE
:bug: Fix post-release workflow for qodana-lsp

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -58,8 +58,10 @@ jobs:
         if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
         run: |
           node scripts/update-cli.js
+          cd vscode/qodana
           npm ci
-          npm run build
+          npm run compile
+          cd ../..
           git config user.name qodana-bot
           git config user.email qodana-support@jetbrains.com
           git checkout -b bump-cli-version


### PR DESCRIPTION
Fix npm ci failure in the post-release workflow for qodana-lsp.

## Changes
- Add `cd vscode/qodana` before npm commands (package.json is located there, not in repo root)
- Change `npm run build` to `npm run compile` (correct script name per CONTRIBUTING.md)
- Add `cd ../..` to return to repo root before git commands

## Problem
The workflow was failing with:
```
npm error The `npm ci` command can only install with an existing package-lock.json
```

This happened because npm ci was executed in the repo root, but package.json and package-lock.json are in `vscode/qodana/` subdirectory.

## Testing
After this fix, the workflow should successfully:
1. Update CLI version with `node scripts/update-cli.js`
2. Install dependencies with `npm ci` in the correct directory
3. Compile the extension with `npm run compile`
4. Create and push a PR to qodana-lsp