### PR TITLE
QD-15179: fix base image builds broken by DHI base-image drift (node, php, clang)

### DIFF
--- a/dockerfiles/base/cpp-bookworm.Dockerfile
+++ b/dockerfiles/base/cpp-bookworm.Dockerfile
@@ -1,5 +1,8 @@
-ARG BASE_TAG="trixie"
-ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
+# Bookworm variant of cpp.Dockerfile for the clang 16-19 targets.
+# Uses debian12 node: its portable upstream-tarball build runs on bookworm, whereas the
+# trixie-native debian13 node binary won't load there (glibc).
+ARG BASE_TAG="bookworm"
+ARG NODE_TAG="22-debian12-dev@sha256:c22523c46225082884240de60f0750fa1996e898a9a26632e90ab8f3bda4e9c7"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM cpp-community
 
@@ -8,13 +11,14 @@ ENV ESLINT_VERSION="9.31.0"
 
 ENV PATH="/opt/yarn/bin:$PATH"
 ENV SKIP_YARN_COREPACK_CHECK=0
-COPY --from=node_base /usr/bin/node /usr/local/bin/
-COPY --from=node_base /usr/lib/nodejs/npm /usr/local/lib/node_modules/npm
-COPY --from=node_base /usr/lib/nodejs/corepack /usr/local/lib/node_modules/corepack
-COPY --from=node_base /usr/lib/nodejs/yarn /opt/yarn/
+COPY --from=node_base /opt/nodejs/node-*/bin/node /usr/local/bin/
+COPY --from=node_base /opt/nodejs/node-*/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node_base /opt/yarn/ /opt/yarn/
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
+    mkdir -p /opt/yarn/bin && ln -s /opt/yarn/yarn-*/bin/yarn /opt/yarn/bin/ && \
+    ln -s /opt/yarn/yarn-*/bin/yarnpkg /opt/yarn/bin/ && \
     node --version && \
     npm --version && \
     npx --version && \

--- a/dockerfiles/base/cpp-community.Dockerfile
+++ b/dockerfiles/base/cpp-community.Dockerfile
@@ -47,17 +47,19 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     echo 'root:x:0:0:root:/root:/bin/bash' > /etc/passwd && chmod 666 /etc/passwd && \
     git config --global --add safe.directory '*'
 
+# clang-$CLANG pulls libobjc-<gcc>-dev which `=`-pins stock gcc-14-base, but the DHI hardened base ships
+# the +dhi rebuild, so apt deadlocks ("held broken packages"). On failure, pin the gcc runtime family to
+# the stock Debian origin and retry with --allow-downgrades.
 RUN echo "deb https://apt.llvm.org/trixie/ llvm-toolchain-trixie-${CLANG} main" > /etc/apt/sources.list.d/llvm.list && \
     curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm.gpg && \
     apt-get -qq update && \
-    apt-get install -qqy -t \
-      llvm-toolchain-trixie-$CLANG \
-      clang-$CLANG \
-      clang-tidy-$CLANG \
-      clang-format-$CLANG \
-      lld-$CLANG \
-      libc++-$CLANG-dev \
-      libc++abi-$CLANG-dev && \
+    if ! apt-get install -qqy -t llvm-toolchain-trixie-$CLANG \
+      clang-$CLANG clang-tidy-$CLANG clang-format-$CLANG lld-$CLANG libc++-$CLANG-dev libc++abi-$CLANG-dev; then \
+      printf 'Package: gcc-*-base libgcc-* libstdc++* libgomp* libitm* libatomic* libasan* liblsan* libtsan* libubsan* libhwasan* libquadmath* libcc1-* libobjc*\nPin: release o=Debian\nPin-Priority: 1001\n' > /etc/apt/preferences.d/gcc-stock && \
+      apt-get install -qqy -t llvm-toolchain-trixie-$CLANG --allow-downgrades \
+      clang-$CLANG clang-tidy-$CLANG clang-format-$CLANG lld-$CLANG libc++-$CLANG-dev libc++abi-$CLANG-dev && \
+      rm -f /etc/apt/preferences.d/gcc-stock; \
+    fi && \
     for f in /usr/lib/llvm-$CLANG/bin/*; do ln -sf "$f" /usr/bin; done && \
     ln -sf clang /usr/bin/cc && \
     ln -sf clang /usr/bin/c89 && \

--- a/dockerfiles/base/docker-bake.hcl
+++ b/dockerfiles/base/docker-bake.hcl
@@ -198,7 +198,7 @@ target "cpp-bookworm" {
     "registry.jetbrains.team/p/sa/containers/qodana:cpp-base-${clang}-latest"
   ]
   platforms = ["linux/amd64", "linux/arm64"]
-  dockerfile = "cpp.Dockerfile"
+  dockerfile = "cpp-bookworm.Dockerfile"
   args = {
     CLANG = clang
   }

--- a/dockerfiles/base/dotnet.Dockerfile
+++ b/dockerfiles/base/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG="trixie"
-ARG NODE_TAG="22-debian13-dev"
+ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM dotnet-community
 
@@ -8,17 +8,17 @@ ENV ESLINT_VERSION="9.31.0"
 
 ENV PATH="/opt/yarn/bin:$PATH" RIDER_UNREAL_ROOT="/data/unrealEngine"
 ENV SKIP_YARN_COREPACK_CHECK=0
-COPY --from=node_base /opt/nodejs/node-*/bin/node /usr/local/bin/
-COPY --from=node_base /opt/nodejs/node-*/include/node /usr/local/include/node
-COPY --from=node_base /opt/nodejs/node-*/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node_base /opt/yarn/ /opt/yarn/
+COPY --from=node_base /usr/bin/node /usr/local/bin/
+COPY --from=node_base /usr/lib/nodejs/npm /usr/local/lib/node_modules/npm
+COPY --from=node_base /usr/lib/nodejs/corepack /usr/local/lib/node_modules/corepack
+COPY --from=node_base /usr/lib/nodejs/yarn /opt/yarn/
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
-    mkdir -p /opt/yarn/bin && ln -s /opt/yarn/yarn-*/bin/yarn /opt/yarn/bin/ && \
-    ln -s /opt/yarn/yarn-*/bin/yarnpkg /opt/yarn/bin/ && \
     node --version && \
     npm --version && \
+    npx --version && \
+    corepack --version && \
     yarn --version && \
     npm install -g eslint@$ESLINT_VERSION && npm config set update-notifier false && \
     mkdir -p $RIDER_UNREAL_ROOT && \

--- a/dockerfiles/base/go.Dockerfile
+++ b/dockerfiles/base/go.Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_TAG="1.26-debian13-dev"
-ARG NODE_TAG="22-debian13-dev"
+ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM dhi.io/golang:$GO_TAG
 
@@ -42,17 +42,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 
 ENV PATH="/opt/yarn/bin:$PATH"
 ENV SKIP_YARN_COREPACK_CHECK=0
-COPY --from=node_base /opt/nodejs/node-*/bin/node /usr/local/bin/
-COPY --from=node_base /opt/nodejs/node-*/include/node /usr/local/include/node
-COPY --from=node_base /opt/nodejs/node-*/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node_base /opt/yarn/ /opt/yarn/
+COPY --from=node_base /usr/bin/node /usr/local/bin/
+COPY --from=node_base /usr/lib/nodejs/npm /usr/local/lib/node_modules/npm
+COPY --from=node_base /usr/lib/nodejs/corepack /usr/local/lib/node_modules/corepack
+COPY --from=node_base /usr/lib/nodejs/yarn /opt/yarn/
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
-    mkdir -p /opt/yarn/bin && ln -s /opt/yarn/yarn-*/bin/yarn /opt/yarn/bin/ && \
-    ln -s /opt/yarn/yarn-*/bin/yarnpkg /opt/yarn/bin/ && \
     node --version && \
     npm --version && \
+    npx --version && \
+    corepack --version && \
     yarn --version && \
     npm install -g eslint@$ESLINT_VERSION && npm config set update-notifier false && \
     chmod 777 -R "$HOME/.npm" "$HOME/.npmrc"

--- a/dockerfiles/base/js.Dockerfile
+++ b/dockerfiles/base/js.Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_TAG="22-debian13-dev"
+ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG
 
 # renovate: datasource=npm depName=eslint
@@ -35,8 +35,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     chmod 777 -R $HOME && \
     echo 'root:x:0:0:root:/root:/bin/bash' > /etc/passwd && chmod 666 /etc/passwd && \
     git config --global --add safe.directory '*' && \
+    node --version && \
+    npm --version && \
+    yarn --version && \
     npm install -g eslint@$ESLINT_VERSION && npm config set update-notifier false && \
     chmod 777 -R "$HOME/.npm" "$HOME/.npmrc"
 
-ENV PATH="/opt/yarn/bin:$PATH"
 ENV SKIP_YARN_COREPACK_CHECK=0

--- a/dockerfiles/base/jvm.Dockerfile
+++ b/dockerfiles/base/jvm.Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG="trixie"
-ARG NODE_TAG="22-debian13-dev"
+ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM jvm-community
 
@@ -8,17 +8,17 @@ ENV ESLINT_VERSION="9.31.0"
 
 ENV PATH="/opt/yarn/bin:$PATH"
 ENV SKIP_YARN_COREPACK_CHECK=0
-COPY --from=node_base /opt/nodejs/node-*/bin/node /usr/local/bin/
-COPY --from=node_base /opt/nodejs/node-*/include/node /usr/local/include/node
-COPY --from=node_base /opt/nodejs/node-*/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node_base /opt/yarn/ /opt/yarn/
+COPY --from=node_base /usr/bin/node /usr/local/bin/
+COPY --from=node_base /usr/lib/nodejs/npm /usr/local/lib/node_modules/npm
+COPY --from=node_base /usr/lib/nodejs/corepack /usr/local/lib/node_modules/corepack
+COPY --from=node_base /usr/lib/nodejs/yarn /opt/yarn/
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
-    mkdir -p /opt/yarn/bin && ln -s /opt/yarn/yarn-*/bin/yarn /opt/yarn/bin/ && \
-    ln -s /opt/yarn/yarn-*/bin/yarnpkg /opt/yarn/bin/ && \
     node --version && \
     npm --version && \
+    npx --version && \
+    corepack --version && \
     yarn --version && \
     npm install -g eslint@$ESLINT_VERSION && npm config set update-notifier false && \
     chmod 777 -R "$HOME/.npm" "$HOME/.npmrc" && \

--- a/dockerfiles/base/php.Dockerfile
+++ b/dockerfiles/base/php.Dockerfile
@@ -19,10 +19,14 @@ ENV JAVA_HOME="$QODANA_DIST/jbr" \
     PATH="$QODANA_DIST/bin:$PATH"
 
 # hadolint ignore=SC2174,DL3009
+# The dhi.io/php base ships a pre-broken apt state (its gcc-14 has an unsatisfiable binutils dep) that
+# poisons the apt solver; the gated `apt-get --fix-broken install` drops the broken gcc-14 chain (the
+# php image needs no C compiler).
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
+    if ! apt-get check; then apt-get --fix-broken install -y --no-install-recommends; fi && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \

--- a/dockerfiles/base/php.Dockerfile
+++ b/dockerfiles/base/php.Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_TAG="22-debian13-dev"
+ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 ARG PHP_TAG="8.4-dev"
 ARG COMPOSER_TAG="2.8.10"
 FROM dhi.io/node:$NODE_TAG AS node_base
@@ -45,17 +45,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 
 ENV PATH="/opt/yarn/bin:$PATH"
 ENV SKIP_YARN_COREPACK_CHECK=0
-COPY --from=node_base /opt/nodejs/node-*/bin/node /usr/local/bin/
-COPY --from=node_base /opt/nodejs/node-*/include/node /usr/local/include/node
-COPY --from=node_base /opt/nodejs/node-*/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node_base /opt/yarn/ /opt/yarn/
+COPY --from=node_base /usr/bin/node /usr/local/bin/
+COPY --from=node_base /usr/lib/nodejs/npm /usr/local/lib/node_modules/npm
+COPY --from=node_base /usr/lib/nodejs/corepack /usr/local/lib/node_modules/corepack
+COPY --from=node_base /usr/lib/nodejs/yarn /opt/yarn/
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
-    mkdir -p /opt/yarn/bin && ln -s /opt/yarn/yarn-*/bin/yarn /opt/yarn/bin/ && \
-    ln -s /opt/yarn/yarn-*/bin/yarnpkg /opt/yarn/bin/ && \
     node --version && \
     npm --version && \
+    npx --version && \
+    corepack --version && \
     yarn --version && \
     npm install -g eslint@$ESLINT_VERSION && npm config set update-notifier false && \
     chmod 777 -R "$HOME/.npm" "$HOME/.npmrc"

--- a/dockerfiles/base/python.Dockerfile
+++ b/dockerfiles/base/python.Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG="trixie"
-ARG NODE_TAG="22-debian13-dev"
+ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM python-community
 
@@ -8,17 +8,17 @@ ENV ESLINT_VERSION="9.31.0"
 
 ENV PATH="/opt/yarn/bin:$PATH"
 ENV SKIP_YARN_COREPACK_CHECK=0
-COPY --from=node_base /opt/nodejs/node-*/bin/node /usr/local/bin/
-COPY --from=node_base /opt/nodejs/node-*/include/node /usr/local/include/node
-COPY --from=node_base /opt/nodejs/node-*/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node_base /opt/yarn/ /opt/yarn/
+COPY --from=node_base /usr/bin/node /usr/local/bin/
+COPY --from=node_base /usr/lib/nodejs/npm /usr/local/lib/node_modules/npm
+COPY --from=node_base /usr/lib/nodejs/corepack /usr/local/lib/node_modules/corepack
+COPY --from=node_base /usr/lib/nodejs/yarn /opt/yarn/
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
-    mkdir -p /opt/yarn/bin && ln -s /opt/yarn/yarn-*/bin/yarn /opt/yarn/bin/ && \
-    ln -s /opt/yarn/yarn-*/bin/yarnpkg /opt/yarn/bin/ && \
     node --version && \
     npm --version && \
+    npx --version && \
+    corepack --version && \
     yarn --version && \
     npm install -g eslint@$ESLINT_VERSION && npm config set update-notifier false && \
     chmod 777 -R "$HOME/.npm" "$HOME/.npmrc"

--- a/dockerfiles/base/ruby.Dockerfile
+++ b/dockerfiles/base/ruby.Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_TAG="22-debian13-dev"
+ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 ARG RUBY_TAG="3.4-debian13-dev"
 
 FROM dhi.io/node:$NODE_TAG AS node_base
@@ -46,17 +46,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 
 ENV PATH="/opt/yarn/bin:$PATH"
 ENV SKIP_YARN_COREPACK_CHECK=0
-COPY --from=node_base /opt/nodejs/node-*/bin/node /usr/local/bin/
-COPY --from=node_base /opt/nodejs/node-*/include/node /usr/local/include/node
-COPY --from=node_base /opt/nodejs/node-*/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node_base /opt/yarn/ /opt/yarn/
+COPY --from=node_base /usr/bin/node /usr/local/bin/
+COPY --from=node_base /usr/lib/nodejs/npm /usr/local/lib/node_modules/npm
+COPY --from=node_base /usr/lib/nodejs/corepack /usr/local/lib/node_modules/corepack
+COPY --from=node_base /usr/lib/nodejs/yarn /opt/yarn/
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
-    mkdir -p /opt/yarn/bin && ln -s /opt/yarn/yarn-*/bin/yarn /opt/yarn/bin/ && \
-    ln -s /opt/yarn/yarn-*/bin/yarnpkg /opt/yarn/bin/ && \
     node --version && \
     npm --version && \
+    npx --version && \
+    corepack --version && \
     yarn --version && \
     npm install -g eslint@$ESLINT_VERSION && npm config set update-notifier false && \
     chmod 777 -R "$HOME/.npm" "$HOME/.npmrc"


### PR DESCRIPTION
Three DHI hardened base images drifted under their mutable tags and broke `base.yml`. Pre-existing breakage independent of #980 — that PR only *triggered* `base.yml` by touching `dockerfiles/base/`.

[QD-15179](https://youtrack.jetbrains.com/issue/QD-15179)

## Root causes & fixes

- **node** — `dhi.io/node:22-debian13-dev` was repackaged to a Debian-native layout (no C headers), so `COPY --from=node_base /opt/...` fails. → Copy from the new layout, drop the headers, **digest-pin** the image. `cpp.Dockerfile` is split: `cpp` (trixie) joins the other debian13 images; a new `cpp-bookworm.Dockerfile` keeps debian12 node (a trixie node binary won't load on the bookworm base — glibc), mirroring the existing `cpp-community`/`-bookworm` split.
- **php** — `dhi.io/php:8.4-dev` ships a broken gcc-14 (unsatisfiable `binutils` dep) that jams the apt solver. → Gated `apt --fix-broken` drops the broken gcc-14 chain (php needs no compiler).
- **clang** — `apt.llvm.org` clang pulls `libobjc-14-dev`, which `=`-pins stock `gcc-14-base (= 14.2.0-19)`, but DHI ships `+dhi2`. → Gated on failure, pin the stock gcc runtime family and retry with `--allow-downgrades`. **Keeps the hardened base.**

The php/clang repairs mirror `qodana-kotlin-cli`'s `lib/base.dockerfile` + `lib/toolchain/clang.dockerfile`.

## Verify

Built on arm64 locally; CI `🐳 Base` is the multi-arch gate.

## Follow-ups (separate tickets)

- Centralize the DHI apt-repairs so they don't drift from `qodana-kotlin-cli`.
- Digest-pin the remaining DHI bases (`golang`/`ruby`/`php`/`debian-base`).
- De-dup the node-install block shared across the base Dockerfiles.

## With #980

Once merged, #980 rebases to drop the Codex Dockerfile commits and stays a clean rename.
