### PR TITLE
QD-14845: include opengrep plugin for jvm linter

### DIFF
--- a/dockerfiles/jvm/included_plugins.txt
+++ b/dockerfiles/jvm/included_plugins.txt
@@ -90,3 +90,5 @@ com.intellij.hardcodedPasswords
 com.intellij.mcpServer
 org.intellij.plugins.markdown
 com.intellij.copyright
+intellij.opengrep
+com.intellij.dfa.analysis


### PR DESCRIPTION
Allow opengrep and dfa.analysis plugins in qodana-jvm plugins list