### PR TITLE
QD-15281 Fix dockerfiles.py to allow generation without release feeds

### DIFF
--- a/scripts/dockerfiles.py
+++ b/scripts/dockerfiles.py
@@ -264,9 +264,8 @@ def generate_variant_dockerfile(
         # For IntelliJ-based variants (not third-party), load release info from local feeds
         release_info = load_release_info(qd_code, qd_version)
         if not release_info:
-            # If we can't find release info, skip this variant
-            logger.warning("Skipping variant '%s' due to missing release information.", variant)
-            return ""
+            logger.info("No release info for '%s' — Dockerfile will resolve at build time.", variant)
+            release_info = {"build": "", "downloads": {}}
 
         template = intellij_template
         snippet = template.render(


### PR DESCRIPTION
## Summary
Port fix from 261 branch to allow Dockerfile generation without release feeds in main branch.

## Problem
Currently `dockerfiles.py` script skips variants when release information is not found in feeds. This prevents generating Dockerfiles for new versions before their releases are published.

## Solution
- Changed logic to generate Dockerfiles with empty build args when release info is missing
- Dockerfiles will resolve versions at docker build time via `QD_RELEASE` parameter

## Changes
- Modified `scripts/dockerfiles.py` to set `release_info = {"build": "", "downloads": {}}` instead of returning empty string
- Changed log level from `warning` to `info` for missing release info

## Related
- Cherry-picked fix from commit 0a5a3e24 (261 branch)
- Same fix applied to 262 branch in PR #988