### PR TITLE
:bug: QD-15282: fix non-root DHI base in public Dockerfiles (jvm/cpp/dotnet/python)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,10 @@ on:
     paths:
       - 'dockerfiles/**/*.Dockerfile'
       - 'dockerfiles/**/*.j2'
+      - 'dockerfiles/public.json'
       - 'scripts/dockerfiles.py'
+      - 'scripts/validate_dockerfiles_base.py'
+      - 'scripts/validate_dockerfiles_base_test.py'
 
 jobs:
   lint:
@@ -17,6 +20,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
+      - name: Validate base image tags
+        run: |
+          pip install jinja2 pytest
+          pytest scripts/validate_dockerfiles_base_test.py -q
       - name: Check if Dockerfiles exist
         id: check
         run: |
@@ -51,7 +58,7 @@ jobs:
               git diff --ignore-space-at-eol HEAD -- dockerfiles
               git config user.name github-actions
               git config user.email github-actions@github.com
-              git add .
+              git add dockerfiles
               git commit -m "QD-8148 Update Dockerfiles"
               git push
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,8 @@ dist/
 # see https://code.claude.com/docs/en/settings#configuration-scopes
 .claude/*.local.*
 CLAUDE.local.md
+
+# Python (scripts/ tooling and its tests)
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/dockerfiles/base/cpp.Dockerfile
+++ b/dockerfiles/base/cpp.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG="trixie"
+ARG BASE_TAG="trixie-debian13-dev"
 ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM cpp-community

--- a/dockerfiles/base/dotnet.Dockerfile
+++ b/dockerfiles/base/dotnet.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG="trixie"
+ARG BASE_TAG="trixie-debian13-dev"
 ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM dotnet-community

--- a/dockerfiles/base/jvm.Dockerfile
+++ b/dockerfiles/base/jvm.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG="trixie"
+ARG BASE_TAG="trixie-debian13-dev"
 ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM jvm-community

--- a/dockerfiles/base/python.Dockerfile
+++ b/dockerfiles/base/python.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG="trixie"
+ARG BASE_TAG="trixie-debian13-dev"
 ARG NODE_TAG="22-debian13-dev@sha256:6193eadf230e43b9df82c4340e1f98223d2ef41ec83bde0ba32ccc3dbf11b0b1"
 FROM dhi.io/node:$NODE_TAG AS node_base
 FROM python-community

--- a/scripts/validate_dockerfiles_base.py
+++ b/scripts/validate_dockerfiles_base.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Validate that generated public Dockerfiles build on root-capable DHI base images.
+
+scripts/dockerfiles.py generates each RC image's Dockerfile by flattening <lang>.Dockerfile with
+its inlined <lang>-community bases. Docker resolves ARG-tagged FROM lines only from ARGs declared
+before the first FROM (the "global" scope). Every `FROM dhi.io/...` base runs the image's
+root-requiring build steps (apt-get install, chmod 777 $HOME, echo 'root:...' > /etc/passwd), so
+each must resolve to a root DHI "-dev" variant; the hardened non-root variant breaks those steps.
+
+This flattens each public variant with the real generator (substitute_from_directives). It fails
+closed: a `FROM dhi.io/...` ref it cannot prove is "-dev" (a bare digest, an untagged base, an
+unexpandable variable, an empty resolution) is a violation. Root-ness is the DHI "-dev" naming
+convention (digest stripped) — an image's runtime user cannot be queried offline, and the lint CI
+has no Docker daemon or dhi.io registry access.
+
+The generator also appends a Jinja template snippet to each Dockerfile; the flatten does not render
+it, so check_templates asserts the templates contain no FROM of their own.
+
+Run from the repo root:
+    ./scripts/validate_dockerfiles_base.py
+"""
+import glob
+import re
+import sys
+from typing import List, Optional
+
+from dockerfiles import load_variants, substitute_from_directives
+
+BASE_DIR = "dockerfiles/base"
+
+# Bare `FROM <name>` bases that are not build stages and never inlined includes.
+KNOWN_BARE_BASES = {"scratch"}
+
+# Docker treats FROM/ARG keywords case-insensitively and ignores leading whitespace before them;
+# variable names stay case-sensitive.
+FIRST_FROM_RE = re.compile(r"^[ \t]*FROM\s", re.MULTILINE | re.IGNORECASE)
+DHI_FROM_RE = re.compile(r"^[ \t]*FROM\s+(?:--\S+\s+)*(dhi\.io/\S+)", re.MULTILINE | re.IGNORECASE)
+REF_RE = re.compile(r"[:@](.+)$")
+VAR_REF_RE = re.compile(r"^\$\{?(\w+)\}?$")
+STAGE_NAME_RE = re.compile(r"^[ \t]*FROM\s+.+?\s+AS\s+(\S+)", re.MULTILINE | re.IGNORECASE)
+BARE_FROM_RE = re.compile(r"^[ \t]*FROM\s+([A-Za-z][\w.-]*)\s*$", re.MULTILINE | re.IGNORECASE)
+INDIRECT_FROM_RE = re.compile(r"^[ \t]*FROM\s+(?:--\S+\s+)*(\$\S+|\{\{.*?\}\})", re.MULTILINE | re.IGNORECASE)
+
+
+def is_root_tag(tag: Optional[str]) -> bool:
+    """DHI root build bases are the '-dev' variants; strip any @digest first."""
+    return bool(tag) and tag.split("@", 1)[0].endswith("-dev")
+
+
+def global_arg(flattened: str, name: str) -> Optional[str]:
+    """The last global `ARG <name>` (before the first FROM) — the value Docker uses in FROM lines."""
+    first_from = FIRST_FROM_RE.search(flattened)
+    head = flattened[: first_from.start()] if first_from else flattened
+    pat = re.compile(rf'^[ \t]*(?i:ARG)\s+{re.escape(name)}=(?:"([^"]*)"|(\S+))', re.MULTILINE)
+    values = [quoted if quoted else bare for quoted, bare in pat.findall(head)]
+    return values[-1] if values else None
+
+
+def resolved_dhi_base_tags(flattened: str) -> List[str]:
+    """Resolve every `dhi.io/<repo>` FROM to its tag; untagged/unexpandable-$VAR → "" (fail-closed)."""
+    tags = []
+    for image in DHI_FROM_RE.findall(flattened):
+        ref = REF_RE.search(image[len("dhi.io/"):])
+        if ref is None:
+            tags.append("")  # untagged (implicit :latest) — unprovable
+            continue
+        token = ref.group(1)
+        var = VAR_REF_RE.match(token)
+        if var:
+            tags.append(global_arg(flattened, var.group(1)) or "")
+        elif "$" in token:
+            tags.append("")  # unresolved composite variable (e.g. $BASE_TAG-dev) — fail-closed
+        else:
+            tags.append(token)
+    return tags
+
+
+def unresolved_includes(flattened: str) -> List[str]:
+    """Bare `FROM <name>` left by a failed include (name is neither a build stage nor a known base)."""
+    stages = {s.lower() for s in STAGE_NAME_RE.findall(flattened)}
+    return sorted(
+        {
+            name
+            for name in BARE_FROM_RE.findall(flattened)
+            if name.lower() not in stages and name.lower() not in KNOWN_BARE_BASES
+        }
+    )
+
+
+def check_flattened(variant: str, flattened: str) -> List[str]:
+    msgs = [
+        f"{variant}: unresolved FROM include (missing base file?): {name}"
+        for name in unresolved_includes(flattened)
+    ]
+
+    msgs += [
+        f"{variant}: FROM uses a variable image reference {ref!r} — cannot prove it is a root base"
+        for ref in INDIRECT_FROM_RE.findall(flattened)
+    ]
+
+    tags = resolved_dhi_base_tags(flattened)
+    if not tags:
+        msgs.append(f"{variant}: no dhi.io base image FROM found (base check would pass vacuously)")
+    msgs += [
+        f"{variant}: FROM dhi.io base pins {tag!r}, not a provable root DHI '-dev' tag"
+        for tag in tags
+        if not is_root_tag(tag)
+    ]
+    return msgs
+
+
+def check_templates(base_dir: str = BASE_DIR) -> List[str]:
+    """The .j2 snippets are appended verbatim to each Dockerfile but never flattened here; they are
+    trailing layers, so any FROM (literal or variable) would introduce an unvalidated build base."""
+    templates = sorted(glob.glob(f"{base_dir}/templates/*.j2"))
+    if not templates:
+        return [f"no .j2 templates found under {base_dir}/templates — this guard would pass vacuously"]
+    msgs = []
+    for path in templates:
+        with open(path, encoding="utf-8") as f:
+            if FIRST_FROM_RE.search(f.read()):
+                msgs.append(f"{path}: template must not contain a FROM (it would introduce an unvalidated base)")
+    return msgs
+
+
+def collect_violations(base_dir: str = BASE_DIR) -> List[str]:
+    variants = load_variants()
+    if not variants:
+        return ["no variants found in public.json — nothing validated"]
+    violations: List[str] = check_templates(base_dir)
+    for variant, data in variants.items():
+        base_source = data.get("from", variant)
+        base_path = f"{base_dir}/{base_source}.Dockerfile"
+        try:
+            with open(base_path, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            violations.append(f"{variant}: cannot read base {base_path}: {e}")
+            continue
+        violations.extend(check_flattened(variant, substitute_from_directives(content, base_dir)))
+    return violations
+
+
+def main() -> None:
+    violations = collect_violations()
+    if violations:
+        print("ERROR: public Dockerfile base-image validation failed:")
+        for v in violations:
+            print(f"  - {v}")
+        print(
+            "\nEvery `FROM dhi.io/...` base runs the image's root build steps (apt-get, chmod, npm "
+            "install -g) and must resolve to a root DHI '-dev' tag; the hardened variant runs non-root."
+        )
+        sys.exit(1)
+    print("OK: all public variants build on root-capable dhi.io '-dev' base images.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_dockerfiles_base_test.py
+++ b/scripts/validate_dockerfiles_base_test.py
@@ -1,0 +1,189 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from dockerfiles import load_variants, substitute_from_directives  # noqa: E402
+from validate_dockerfiles_base import (  # noqa: E402
+    check_flattened,
+    check_templates,
+    collect_violations,
+    global_arg,
+    is_root_tag,
+    resolved_dhi_base_tags,
+    unresolved_includes,
+)
+
+# Flattened shapes as substitute_from_directives emits them.
+SHADOWED = '''ARG BASE_TAG="trixie"
+ARG NODE_TAG="22-debian13-dev@sha256:abc"
+FROM dhi.io/node:$NODE_TAG AS node_base
+ARG BASE_TAG="trixie-debian13-dev"
+FROM dhi.io/debian-base:$BASE_TAG
+'''
+FIXED = SHADOWED.replace('ARG BASE_TAG="trixie"', 'ARG BASE_TAG="trixie-debian13-dev"')
+COMMUNITY = 'ARG BASE_TAG="trixie-debian13-dev"\nFROM dhi.io/debian-base:$BASE_TAG\n'
+LANG_BASE = 'ARG GO_TAG="1.26-debian13-dev"\nFROM dhi.io/golang:$GO_TAG\n'
+LANG_BASE_NONROOT = 'ARG GO_TAG="1.26"\nFROM dhi.io/golang:$GO_TAG\n'
+BRACE = 'ARG BASE_TAG="trixie-debian13-dev"\nFROM dhi.io/debian-base:${BASE_TAG}\n'
+UNQUOTED_ROOT = 'ARG BASE_TAG=trixie-debian13-dev\nFROM dhi.io/debian-base:$BASE_TAG\n'
+LAST_WINS = ('ARG BASE_TAG="trixie"\nARG BASE_TAG="trixie-debian13-dev"\n'
+             'FROM dhi.io/debian-base:$BASE_TAG\n')
+PLATFORM_LITERAL = 'FROM --platform=$TARGETPLATFORM dhi.io/debian-base:trixie\n'
+DIGEST_ONLY = 'FROM dhi.io/debian-base@sha256:abc123\n'
+NON_DHI = 'FROM debian:bookworm-slim\nRUN echo hi\n'
+UNTAGGED = 'ARG BASE_TAG="trixie-debian13-dev"\nFROM dhi.io/debian-base:$BASE_TAG\nFROM dhi.io/newbase\n'
+UNDEFINED_VAR = 'ARG BASE_TAG="trixie-debian13-dev"\nFROM dhi.io/debian-base:$OTHER_TAG\n'
+COMPOSITE_VAR = 'ARG BASE_TAG="trixie"\nFROM dhi.io/debian-base:$BASE_TAG-dev\n'
+LOWER_FROM = 'ARG BASE_TAG="trixie"\nfrom dhi.io/debian-base:$BASE_TAG\n'
+INDENTED_FROM = 'ARG BASE_TAG="trixie"\n    FROM dhi.io/debian-base:$BASE_TAG\n'
+INDIRECT_IMAGE = 'ARG BASE_TAG="trixie-debian13-dev"\nFROM dhi.io/debian-base:$BASE_TAG\nFROM $SOME_IMAGE\n'
+
+
+@pytest.fixture(autouse=True)
+def _chdir_repo_root():
+    old = os.getcwd()
+    os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    yield
+    os.chdir(old)
+
+
+def test_is_root_tag():
+    assert is_root_tag("trixie-debian13-dev")
+    assert is_root_tag("trixie-debian13-dev@sha256:abc")
+    assert is_root_tag("8.4-dev")
+    assert not is_root_tag("trixie")
+    assert not is_root_tag("sha256:abc")
+    assert not is_root_tag(None)
+    assert not is_root_tag("")
+
+
+def test_global_arg_scope_last_wins_and_unquoted():
+    assert global_arg(SHADOWED, "BASE_TAG") == "trixie"  # community ARG (after a FROM) is ignored
+    assert global_arg(SHADOWED, "NODE_TAG") == "22-debian13-dev@sha256:abc"
+    assert global_arg(COMMUNITY, "BASE_TAG") == "trixie-debian13-dev"
+    assert global_arg(UNQUOTED_ROOT, "BASE_TAG") == "trixie-debian13-dev"
+    assert global_arg(LAST_WINS, "BASE_TAG") == "trixie-debian13-dev"
+    assert global_arg(COMMUNITY, "MISSING") is None
+
+
+def test_resolved_tags_cover_every_dhi_base_and_form():
+    assert resolved_dhi_base_tags(SHADOWED) == ["22-debian13-dev@sha256:abc", "trixie"]
+    assert resolved_dhi_base_tags(LANG_BASE) == ["1.26-debian13-dev"]
+    assert resolved_dhi_base_tags(BRACE) == ["trixie-debian13-dev"]
+    assert resolved_dhi_base_tags(PLATFORM_LITERAL) == ["trixie"]
+    assert resolved_dhi_base_tags(DIGEST_ONLY) == ["sha256:abc123"]
+    assert resolved_dhi_base_tags(NON_DHI) == []
+
+
+def test_check_flattened_flags_non_root_across_bases():
+    shadow = check_flattened("jvm", SHADOWED)
+    assert any("'trixie'" in m and "not a provable root" in m for m in shadow)
+    assert check_flattened("jvm", FIXED) == []
+    assert check_flattened("jvm-community", COMMUNITY) == []
+    assert check_flattened("go", LANG_BASE) == []
+    go_bad = check_flattened("go", LANG_BASE_NONROOT)  # non-debian DHI base is guarded too
+    assert len(go_bad) == 1 and "'1.26'" in go_bad[0]
+    assert len(check_flattened("d", DIGEST_ONLY)) == 1  # fail-closed on a bare digest
+
+
+def test_check_flattened_flags_variant_with_no_dhi_base():
+    out = check_flattened("weird", NON_DHI)
+    assert len(out) == 1 and "no dhi.io base image FROM" in out[0]
+
+
+def test_untagged_dhi_base_fails_closed():
+    # an untagged `FROM dhi.io/newbase` is an implicit :latest — unprovable
+    assert resolved_dhi_base_tags(UNTAGGED) == ["trixie-debian13-dev", ""]
+    assert len(check_flattened("x", UNTAGGED)) == 1
+
+
+def test_variable_image_reference_fails_closed():
+    out = check_flattened("x", INDIRECT_IMAGE)
+    assert len(out) == 1 and "variable image reference" in out[0]
+
+
+def test_undefined_variable_fails_closed():
+    assert resolved_dhi_base_tags(UNDEFINED_VAR) == [""]
+    out = check_flattened("x", UNDEFINED_VAR)
+    assert len(out) == 1 and "not a provable root" in out[0]
+
+
+def test_composite_variable_ref_fails_closed():
+    # `$BASE_TAG-dev` is not a pure variable, so it is unresolvable, not a literal ending in -dev
+    assert resolved_dhi_base_tags(COMPOSITE_VAR) == [""]
+    assert len(check_flattened("x", COMPOSITE_VAR)) == 1
+
+
+def test_real_templates_introduce_no_dhi_base():
+    # passes only because real templates exist and are clean; an empty match is a loud violation
+    assert check_templates() == []
+
+
+def test_template_with_any_from_is_flagged(tmp_path):
+    # a variable-image FROM must be caught too, not only a literal dhi.io one
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "bad.Dockerfile.j2").write_text("FROM {{ base }}\nRUN echo hi\n")
+    out = check_templates(str(tmp_path))
+    assert len(out) == 1 and "must not contain a FROM" in out[0]
+
+
+def test_no_templates_is_loud(tmp_path):
+    (tmp_path / "templates").mkdir()
+    out = check_templates(str(tmp_path))
+    assert len(out) == 1 and "pass vacuously" in out[0]
+
+
+def test_lowercase_from_is_validated():
+    assert resolved_dhi_base_tags(LOWER_FROM) == ["trixie"]
+    assert any("not a provable root" in m for m in check_flattened("x", LOWER_FROM))
+
+
+def test_indented_from_is_validated():
+    assert resolved_dhi_base_tags(INDENTED_FROM) == ["trixie"]
+    assert any("not a provable root" in m for m in check_flattened("x", INDENTED_FROM))
+
+
+def test_empty_public_json_is_loud(monkeypatch):
+    import validate_dockerfiles_base as v
+    monkeypatch.setattr(v, "load_variants", lambda *a, **k: {})
+    out = v.collect_violations()
+    assert out and "no variants found" in out[0]
+
+
+def test_unresolved_include_detected_but_stages_and_scratch_ignored():
+    flattened = substitute_from_directives("FROM does-not-exist-base\n", "dockerfiles/base")
+    assert unresolved_includes(flattened) == ["does-not-exist-base"]
+    staged = "FROM dhi.io/debian-base:trixie-debian13-dev AS builder\nFROM builder\n"
+    assert unresolved_includes(staged) == []
+    assert unresolved_includes("FROM scratch\n") == []
+
+
+def test_check_flattened_reports_unresolved_and_still_base_checks():
+    both = "FROM ghost-base\nFROM dhi.io/debian-base:trixie\n"
+    out = check_flattened("x", both)
+    assert any("unresolved FROM include" in m and "ghost-base" in m for m in out)
+    assert any("not a provable root" in m for m in out)
+
+
+def test_missing_base_dir_is_loud():
+    violations = collect_violations(base_dir="/definitely/not/here")
+    assert any("cannot read base" in v for v in violations)
+
+
+def test_real_variants_resolve_to_root_dev_tags():
+    for variant, data in load_variants().items():
+        base = data.get("from", variant)
+        with open(f"dockerfiles/base/{base}.Dockerfile", encoding="utf-8") as fh:
+            flattened = substitute_from_directives(fh.read(), "dockerfiles/base")
+        tags = resolved_dhi_base_tags(flattened)
+        assert tags, f"{variant}: no dhi.io base FROM found"
+        for tag in tags:
+            assert is_root_tag(tag), f"{variant}: dhi.io base resolves to {tag!r}"
+
+
+def test_real_base_files_pass():
+    assert collect_violations() == []


### PR DESCRIPTION
## Problem

The `Publish RC` builds for **jvm, cpp, dotnet, python, android** fail while building the public Dockerfile:

```
rm: cannot remove '/etc/apt/apt.conf.d/docker-clean': Permission denied
```

The generator (`scripts/dockerfiles.py`) flattens `<lang>.Dockerfile` + its inlined `<lang>-community` base into one Dockerfile. The leaf declares a global `ARG BASE_TAG="trixie"` (before the first `FROM`), which shadows the community's `trixie-debian13-dev` — and Docker resolves `$BASE_TAG` in `FROM` lines only from pre-first-`FROM` ARGs. So `FROM dhi.io/debian-base:$BASE_TAG` pulled the hardened **non-root** `trixie` image (recent DHI drift), breaking the root-requiring `apt`/`rm`/`chmod` steps. Latent since QD-13151; triggered when DHI made `trixie` non-root.

## Fix

`ARG BASE_TAG="trixie"` → `"trixie-debian13-dev"` in `dockerfiles/base/{jvm,cpp,dotnet,python}.Dockerfile` (fixes android too — its public.json `from` is `jvm`).

## Regression guard

`scripts/validate_dockerfiles_base.py` (+ tests), run in `lint.yml` on `main` PRs: flattens every `public.json` variant with the real generator and asserts each `FROM dhi.io/...` base resolves to a root DHI `-dev` tag. Fails closed on anything it can't prove `-dev` (bare digest, untagged, unresolvable/variable ref), covers **all** DHI language bases (debian-base/node/golang/php/ruby), and rejects any `FROM` sneaking into a `.j2` template.

## Deliberate mitigation (not a blocker)

The parent and community files each declare `BASE_TAG` and must agree — a dual source of truth the flatten forces (the community's ARG loses global scope post-inline; the standalone `*-community` bake target still needs its own). This PR guards the drift rather than eliminating it. The deeper fix (hoist an include's pre-first-`FROM` global ARGs in `substitute_from_directives`, dropping the parent redeclarations) is left as a tracked follow-up.

## Follow-up

The generated public Dockerfiles are committed only on release branches; a separate `azhukova/QD-15282-for-262` PR will regenerate them on `262`.

QD-15282
