### PR TITLE
:bug: QD-15290: render missing-release Dockerfiles + make QD_VERSION an overridable ARG

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
       - 'dockerfiles/**/*.j2'
       - 'dockerfiles/public.json'
       - 'scripts/dockerfiles.py'
+      - 'scripts/dockerfiles_test.py'
       - 'scripts/validate_dockerfiles_base.py'
       - 'scripts/validate_dockerfiles_base_test.py'
 
@@ -23,7 +24,7 @@ jobs:
       - name: Validate base image tags
         run: |
           pip install jinja2 pytest
-          pytest scripts/validate_dockerfiles_base_test.py -q
+          pytest scripts/ -q
       - name: Check if Dockerfiles exist
         id: check
         run: |

--- a/dockerfiles/base/templates/intellij.Dockerfile.j2
+++ b/dockerfiles/base/templates/intellij.Dockerfile.j2
@@ -1,5 +1,6 @@
 ARG QD_RELEASE=""
-ENV QD_VERSION="{{ qd_version }}" QD_IMAGE="{{ qd_image }}"
+ARG QD_VERSION="{{ qd_version }}"
+ENV QD_VERSION="$QD_VERSION" QD_IMAGE="{{ qd_image }}"
 ARG QD_CODE="{{ qd_code }}"
 ARG QD_BUILD="{{ qd_build }}"
 ARG QD_DOWNLOAD_URL_LINUX="{{ qd_downloads.get('linux', {}).get('Link', '') }}"

--- a/scripts/dockerfiles.py
+++ b/scripts/dockerfiles.py
@@ -52,8 +52,8 @@ def load_release_info(qd_code: str, qd_version: str) -> Dict[str, Any]:
 
     feed_name = product_mapping.get(qd_code)
     if not feed_name:
-        logger.warning("Unknown product code '%s'. Skipping release info lookup.", qd_code)
-        return {}
+        logger.error("Unknown product code '%s'.", qd_code)
+        raise ValueError(f"Unknown product code '{qd_code}'")
 
     feed_url = f"https://download.jetbrains.com/qodana/feed/{feed_name}.releases.json"
 
@@ -62,18 +62,18 @@ def load_release_info(qd_code: str, qd_version: str) -> Dict[str, Any]:
             feed_data = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         if e.code == 404:
-            logger.warning("Feed URL '%s' not found (404). Skipping.", feed_url)
+            # No public feed yet for a pre-release-only linter.
+            logger.warning("Feed URL '%s' not found (404). Using empty fallbacks.", feed_url)
             return {}
-        else:
-            logger.error("HTTP error fetching feed URL '%s': %s", feed_url, e)
-            raise
+        logger.error("HTTP error fetching feed URL '%s': %s", feed_url, e)
+        raise
     except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
         logger.error("Error fetching feed URL '%s': %s", feed_url, e)
         raise
 
     releases = feed_data.get("Releases", [])
     if not releases:
-        logger.warning("No releases found in feed URL '%s'. Skipping.", feed_url)
+        logger.warning("No releases found in feed URL '%s'. Using empty fallbacks.", feed_url)
         return {}
 
     # Sort releases by Type and Date, then filter by MajorVersion
@@ -192,15 +192,11 @@ def substitute_from_directives(content: str, base_dir: str) -> str:
             identifier = match.group(2)
             file_path = os.path.join(base_dir, f"{identifier}.Dockerfile")
             if os.path.isfile(file_path):
-                try:
-                    with open(file_path, "r", encoding="utf-8") as inc_file:
-                        included_content = inc_file.read()
-                    # Recursively process the included file's content
-                    substituted_content = substitute_from_directives(included_content, base_dir)
-                    new_lines.append(substituted_content.rstrip())
-                except OSError as e:
-                    logger.error("Error reading included file '%s': %s", file_path, e)
-                    new_lines.append(line)
+                with open(file_path, "r", encoding="utf-8") as inc_file:
+                    included_content = inc_file.read()
+                # Recursively process the included file's content
+                substituted_content = substitute_from_directives(included_content, base_dir)
+                new_lines.append(substituted_content.rstrip())
             else:
                 # If no file found, leave the line as is.
                 new_lines.append(line)
@@ -229,23 +225,19 @@ def generate_variant_dockerfile(
         qd_version (str): The Qodana major version (e.g., "2026.1").
 
     Returns:
-        str: The final Dockerfile content, or an empty string if an error occurred.
+        str: The final Dockerfile content. Raises on any error (missing/unreadable base
+        Dockerfile, feed lookup failure, or template render failure).
     """
     base_source = data.get("from", variant)
     base_dockerfile_path = os.path.join(base_dockerfile_dir, f"{base_source}.Dockerfile")
 
     if not os.path.isfile(base_dockerfile_path):
-        logger.warning("Skipping %s: %s not found.", variant, base_dockerfile_path)
-        return ""
+        raise FileNotFoundError(f"base Dockerfile for variant '{variant}' not found: {base_dockerfile_path}")
 
     # Read and process the base Dockerfile content with recursive substitutions
-    try:
-        with open(base_dockerfile_path, "r", encoding="utf-8") as f:
-            base_content = f.read()
-        processed_base_content = substitute_from_directives(base_content, base_dockerfile_dir)
-    except OSError as e:
-        logger.error("Error processing base Dockerfile for variant '%s': %s", variant, e)
-        return ""
+    with open(base_dockerfile_path, "r", encoding="utf-8") as f:
+        base_content = f.read()
+    processed_base_content = substitute_from_directives(base_content, base_dockerfile_dir)
 
     is_third_party = data.get("is_third_party", False)
     qd_code = data.get("qd_code", "")
@@ -261,12 +253,16 @@ def generate_variant_dockerfile(
             qd_image=variant
         )
     else:
-        # For IntelliJ-based variants (not third-party), load release info from local feeds
+        # A missing release renders empty fallbacks rather than failing: a pre-release version has no
+        # feed entry yet, and failing here would deadlock (an RC image can't be built until its dists
+        # are released, but dists can't be validated pre-release without building the image). The
+        # template's release path rebuilds the URL from QD_VERSION + QD_RELEASE (non-release path fails loudly).
         release_info = load_release_info(qd_code, qd_version)
         if not release_info:
-            # If we can't find release info, skip this variant
-            logger.warning("Skipping variant '%s' due to missing release information.", variant)
-            return ""
+            logger.warning(
+                "No public release info for %s %s; generating with empty download fallbacks.",
+                qd_code, qd_version,
+            )
 
         template = intellij_template
         snippet = template.render(
@@ -290,9 +286,6 @@ def write_dockerfile(variant: str, dockerfile_content: str) -> None:
         variant (str): The variant name.
         dockerfile_content (str): The complete Dockerfile content to write.
     """
-    if not dockerfile_content:
-        logger.debug("No Dockerfile content to write for variant '%s'. Skipping.", variant)
-        return
     generated_disclaimer = "# This file was generated by https://github.com/JetBrains/qodana-cli/blob/main/scripts/dockerfiles.py. DO NOT EDIT MANUALLY."
     dockerfile_content = f"{generated_disclaimer}\n\n{dockerfile_content}"
 
@@ -300,12 +293,9 @@ def write_dockerfile(variant: str, dockerfile_content: str) -> None:
     out_path = os.path.join(out_dir, "Dockerfile")
 
     os.makedirs(out_dir, exist_ok=True)
-    try:
-        with open(out_path, "w", encoding="utf-8") as out_file:
-            out_file.write(dockerfile_content)
-        logger.info("Generated %s.", out_path)
-    except OSError as e:
-        logger.error("Error writing output for variant '%s': %s", variant, e)
+    with open(out_path, "w", encoding="utf-8") as out_file:
+        out_file.write(dockerfile_content)
+    logger.info("Generated %s.", out_path)
 
 def main() -> None:
     """
@@ -323,16 +313,26 @@ def main() -> None:
 
     base_dockerfile_dir = "dockerfiles/base"
 
+    failures = []
     for variant, data in variants.items():
-        dockerfile_content = generate_variant_dockerfile(
-            variant,
-            data,
-            base_dockerfile_dir,
-            intellij_template,
-            thirdparty_template,
-            qd_version
-        )
-        write_dockerfile(variant, dockerfile_content)
+        try:
+            dockerfile_content = generate_variant_dockerfile(
+                variant,
+                data,
+                base_dockerfile_dir,
+                intellij_template,
+                thirdparty_template,
+                qd_version
+            )
+            write_dockerfile(variant, dockerfile_content)
+        except Exception:
+            # Aggregate per-variant failures so one run reports all of them instead of aborting on the first.
+            logger.exception("Error generating Dockerfile for '%s'", variant)
+            failures.append(variant)
+
+    if failures:
+        logger.error("Failed to generate/write Dockerfiles for: %s", ", ".join(failures))
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/scripts/dockerfiles_test.py
+++ b/scripts/dockerfiles_test.py
@@ -1,0 +1,153 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import dockerfiles  # noqa: E402
+
+REAL_DOWNLOADS = {
+    "linux": {
+        "Link": "https://example.test/qodana-linux.tar.gz",
+        "ChecksumLink": "https://example.test/qodana-linux.tar.gz.sha256",
+    },
+    "linuxARM64": {
+        "Link": "https://example.test/qodana-arm.tar.gz",
+        "ChecksumLink": "https://example.test/qodana-arm.tar.gz.sha256",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _chdir_repo_root():
+    old = os.getcwd()
+    os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    yield
+    os.chdir(old)
+
+
+def _render_jvm(qd_version):
+    env = dockerfiles.create_jinja_environment()
+    intellij = dockerfiles.load_template(env, "dockerfiles/base/templates/intellij.Dockerfile.j2")
+    thirdparty = dockerfiles.load_template(env, "dockerfiles/base/templates/thirdparty.Dockerfile.j2")
+    data = dockerfiles.load_variants()["jvm"]
+    return dockerfiles.generate_variant_dockerfile(
+        "jvm", data, "dockerfiles/base", intellij, thirdparty, qd_version,
+    )
+
+
+def test_variant_without_matching_release_renders_empty_fallbacks(monkeypatch):
+    monkeypatch.setattr(dockerfiles, "load_release_info", lambda *a, **k: {})
+    out = _render_jvm("2026.2")
+    assert out
+    assert 'ARG QD_BUILD=""' in out
+    assert 'ARG QD_DOWNLOAD_URL_LINUX=""' in out
+    assert 'ARG QD_CHECKSUM_URL_LINUX=""' in out
+    # Empty fallbacks are only safe because the template's non-release path fails loudly.
+    assert 'No release information available for $QD_CODE $QD_VERSION" >&2 && exit 1' in out
+
+
+def test_variant_with_release_info_renders_download_urls(monkeypatch):
+    monkeypatch.setattr(dockerfiles, "load_release_info", lambda *a, **k: {
+        "build": "262.9999", "downloads": REAL_DOWNLOADS,
+    })
+    out = _render_jvm("2026.2")
+    assert 'ARG QD_BUILD="262.9999"' in out
+    assert 'ARG QD_DOWNLOAD_URL_LINUX="https://example.test/qodana-linux.tar.gz"' in out
+    assert 'ARG QD_CHECKSUM_URL_LINUX_ARM64="https://example.test/qodana-arm.tar.gz.sha256"' in out
+
+
+def test_main_succeeds_and_writes_all_variants_for_empty_fallbacks(monkeypatch):
+    monkeypatch.setattr(dockerfiles, "load_release_info", lambda *a, **k: {})
+    written = {}
+    monkeypatch.setattr(dockerfiles, "write_dockerfile",
+                        lambda variant, content: written.__setitem__(variant, content))
+    monkeypatch.setattr(sys, "argv", ["dockerfiles.py", "2026.2"])
+    dockerfiles.main()
+    assert set(written) == set(dockerfiles.load_variants())
+    assert all(written.values())
+
+
+def test_main_aggregates_all_variant_failures_and_exits(monkeypatch):
+    # A failure outside OSError/ValueError is still caught and aggregated.
+    attempted = []
+
+    def boom(variant, *a, **k):
+        attempted.append(variant)
+        raise AttributeError("boom")
+
+    monkeypatch.setattr(dockerfiles, "generate_variant_dockerfile", boom)
+    monkeypatch.setattr(sys, "argv", ["dockerfiles.py", "2026.2"])
+    with pytest.raises(SystemExit) as exc:
+        dockerfiles.main()
+    assert exc.value.code == 1
+    assert set(attempted) == set(dockerfiles.load_variants())
+
+
+def test_main_exits_nonzero_when_a_write_fails(monkeypatch):
+    monkeypatch.setattr(dockerfiles, "load_release_info", lambda *a, **k: {})
+
+    def boom(variant, content):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(dockerfiles, "write_dockerfile", boom)
+    monkeypatch.setattr(sys, "argv", ["dockerfiles.py", "2026.2"])
+    with pytest.raises(SystemExit) as exc:
+        dockerfiles.main()
+    assert exc.value.code == 1
+
+
+def test_main_exits_when_feed_downloads_are_null(monkeypatch):
+    # A matched release with null Downloads makes the template render raise; the catch-all must
+    # aggregate it and exit 1.
+    monkeypatch.setattr(dockerfiles, "load_release_info",
+                        lambda *a, **k: {"build": "262.1", "downloads": None})
+    monkeypatch.setattr(dockerfiles, "write_dockerfile", lambda *a, **k: None)
+    monkeypatch.setattr(sys, "argv", ["dockerfiles.py", "2026.2"])
+    with pytest.raises(SystemExit) as exc:
+        dockerfiles.main()
+    assert exc.value.code == 1
+
+
+def _fake_urlopen_from(fixture_path):
+    data = open(fixture_path, "rb").read()
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return data
+
+    return lambda url, timeout=10: _Resp()
+
+
+def test_load_release_info_parses_real_feed_schema(monkeypatch):
+    # Keep the template-consumed keys (linux/linuxARM64 -> Link/ChecksumLink) validated against
+    # real feed shape.
+    monkeypatch.setattr(dockerfiles.urllib.request, "urlopen",
+                        _fake_urlopen_from("feed/qodana-jvm.releases.json"))
+    info = dockerfiles.load_release_info("QDJVM", "2024.1")
+    assert info["build"] == "241.20036"  # latest of the two 2024.1 releases (sorted by Type, Date)
+    dl = info["downloads"]
+    assert dl["linux"]["Link"] and dl["linux"]["ChecksumLink"]
+    assert dl["linuxARM64"]["Link"] and dl["linuxARM64"]["ChecksumLink"]
+    # A version not present in the feed yields {} (accepted pre-release case).
+    assert dockerfiles.load_release_info("QDJVM", "1999.9") == {}
+
+
+def test_load_release_info_raises_on_unknown_product_code():
+    with pytest.raises(ValueError):
+        dockerfiles.load_release_info("NOSUCHCODE", "2026.1")
+
+
+def test_intellij_template_wires_overridable_qd_version_into_url(monkeypatch):
+    monkeypatch.setattr(dockerfiles, "load_release_info", lambda *a, **k: {})
+    out = _render_jvm("2026.2")
+    assert 'ARG QD_VERSION="2026.2"' in out
+    assert 'ENV QD_VERSION="$QD_VERSION"' in out
+    assert "qodana/$QD_VERSION/" in out


### PR DESCRIPTION
## What

Generator + template changes on `main` supporting the RC download-URL version fix (QD-15290). No committed public Dockerfiles change on `main` (they're generated on release branches); this is the source side, consumed by the `262` PR and future release branches.

- `scripts/dockerfiles.py`: a variant with no matching public release now **renders empty download fallbacks instead of being silently skipped** — a pre-release version legitimately has no feed entry yet, and failing there would deadlock (an RC image can't build until its dists ship, but dists can't be validated pre-release without building). Genuine errors (unknown product code, unreadable base, feed/render failure) now fail loud: `main()` uses a single exception-based model with a catch-all per-variant aggregator that reports every failure (with traceback) before `sys.exit(1)`.
- `dockerfiles/base/templates/intellij.Dockerfile.j2`: `QD_VERSION` becomes an overridable `ARG` (was a bare `ENV`), so the RC build's `--build-arg QD_VERSION=<versionToDeploy>` (see the TeamCity MR) can override the baked default.
- Tests: `scripts/dockerfiles_test.py` (new) covers empty-fallback render + fail-loud guard, populated-release render, real-feed schema/latest-release selection, and per-variant failure aggregation. Wired into CI (`pytest scripts/ -q`).

## Why

The `262` (2026.2) RC 404'd because its committed Dockerfiles baked `QD_VERSION="2026.1"` (the generator was run with `2026.1` since `dockerfiles.py 2026.2` skipped every variant with no public feed). This makes `2026.2` generatable and the version overridable.

Root-cause build: https://buildserver.labs.intellij.net/buildConfiguration/ijplatform_IjPlatform262_QodanaJvmRc/993145273

## Notes
- Recurrence-prevention beyond the build-arg (a branch version source-of-truth) is intentionally out of scope — a missing release **must** stay non-fatal (chicken-and-egg above).

Ticket: https://youtrack.jetbrains.com/issue/QD-15290