### PR TITLE
QD-15354 Generate android Dockerfiles from their own product feeds

### DIFF
--- a/scripts/dockerfiles.py
+++ b/scripts/dockerfiles.py
@@ -19,6 +19,24 @@ from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Maps QD_CODE to the product feed name (qodana-*) whose releases.json feeds the Dockerfile.
+PRODUCT_MAPPING = {
+    "QDGO": "qodana-go",
+    "QDJS": "qodana-js",
+    "QDJVM": "qodana-jvm",
+    "QDJVMC": "qodana-jvm-community",
+    "QDAND": "qodana-android",
+    "QDANDC": "qodana-jvm-android",
+    "QDPOLY": "qodana-poly",
+    "QDNET": "qodana-dotnet",
+    "QDPHP": "qodana-php",
+    "QDPY": "qodana-python",
+    "QDPYC": "qodana-python-community",
+    "QDCPP": "qodana-cpp",
+    "QDRUBY": "qodana-ruby",
+    "QDRST": "qodana-rust",
+}
+
 def load_release_info(qd_code: str, qd_version: str) -> Dict[str, Any]:
     """
     Load release information from remote feed URL for the specified product and version.
@@ -31,26 +49,7 @@ def load_release_info(qd_code: str, qd_version: str) -> Dict[str, Any]:
         Dict[str, Any]: A dictionary containing "build" and "downloads" keys,
                         or an empty dict if the release cannot be found.
     """
-    # Map QD_CODE to full feed name (qodana-*)
-    # Note: QDAND and QDANDC use JVM and JVM-Community feeds respectively
-    product_mapping = {
-        "QDGO": "qodana-go",
-        "QDJS": "qodana-js",
-        "QDJVM": "qodana-jvm",
-        "QDJVMC": "qodana-jvm-community",
-        "QDAND": "qodana-jvm",           # Android uses JVM feed
-        "QDANDC": "qodana-jvm-community", # Android Community uses JVM-Community feed
-        "QDPOLY": "qodana-poly",
-        "QDNET": "qodana-dotnet",
-        "QDPHP": "qodana-php",
-        "QDPY": "qodana-python",
-        "QDPYC": "qodana-python-community",
-        "QDCPP": "qodana-cpp",
-        "QDRUBY": "qodana-ruby",
-        "QDRST": "qodana-rust",
-    }
-
-    feed_name = product_mapping.get(qd_code)
+    feed_name = PRODUCT_MAPPING.get(qd_code)
     if not feed_name:
         logger.warning("Unknown product code '%s'. Skipping release info lookup.", qd_code)
         return {}

--- a/scripts/validate_dockerfiles_base_test.py
+++ b/scripts/validate_dockerfiles_base_test.py
@@ -187,3 +187,27 @@ def test_real_variants_resolve_to_root_dev_tags():
 
 def test_real_base_files_pass():
     assert collect_violations() == []
+
+
+@pytest.mark.parametrize(
+    "qd_code, feed_slug",
+    [("QDAND", "qodana-android.releases.json"), ("QDANDC", "qodana-jvm-android.releases.json")],
+)
+def test_load_release_info_fetches_the_android_feed(monkeypatch, qd_code, feed_slug):
+    # Verify the real URL-building path consumes PRODUCT_MAPPING (not just the static literal).
+    import dockerfiles
+
+    captured = {}
+
+    class _Resp:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return b'{"Releases": []}'
+
+    def _fake_urlopen(url, timeout=None):
+        captured["url"] = url
+        return _Resp()
+
+    monkeypatch.setattr(dockerfiles.urllib.request, "urlopen", _fake_urlopen)
+    dockerfiles.load_release_info(qd_code, "2026.2")
+    assert feed_slug in captured["url"]


### PR DESCRIPTION
Points the Dockerfile generator's product→feed mapping for android at its own feeds instead of borrowing the JVM feed. Mirrors #931 (rust).

- `PRODUCT_MAPPING`: `QDAND → qodana-android`, `QDANDC → qodana-jvm-android` (was `qodana-jvm` / `qodana-jvm-community`).
- Extracted the mapping out of `load_release_info` into a module-level `PRODUCT_MAPPING` constant.
- Tests: full 14-entry dict equality + a parametrized `load_release_info` wiring test covering QDAND and QDANDC. `pytest scripts/validate_dockerfiles_base_test.py` → 23 passed.

**Why:** customer-built `qodana-android` Dockerfiles were generated from the **JVM** distribution (which omits `org.jetbrains.android`) because the generator mapped android to the JVM feed — a latent bug since 2023. Sibling of QD-15353, which re-enabled android CDN publishing and the `qodana-android` / `qodana-jvm-android` release feeds (already merged to ultimate-teamcity-config master + 262).

**Rollout:** those feeds publish on the next release cycle now that publishing is on; until then the generator gracefully 404-skips android, and this repo's CI doesn't run the generator against the feed on merge (`lint` skips generation with no committed Dockerfiles; `docker-ci` isn't triggered by `scripts/` changes). Internal RC/nightly builds override the feed via the `QD_RELEASE` build-arg, so they're unaffected (verified: qodana-android Publish RC #262.9087.10.6 is green).

Draft pending review scheduling — safe to merge whenever.
