### PR TITLE
Vladimir.shtarev/qd 15655master

### DIFF
--- a/internal/core/startup/installers.go
+++ b/internal/core/startup/installers.go
@@ -384,40 +384,132 @@ func downloadCustomPlugins(ideUrl string, targetDir string, spinner *pterm.Spinn
 	}
 
 	log.Debugf("Downloading custom plugins from %s to %s", pluginsUrl, targetDir)
+	hadPrevious := hasCustomPluginsInstall(targetDir)
 
 	if err := os.MkdirAll(targetDir, os.ModePerm); err != nil {
-		return fmt.Errorf("couldn't create a directory %s: %v", targetDir, err)
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("couldn't create a directory %s: %v", targetDir, err))
 	}
+	cleanupStaleCustomPluginsStaging(targetDir)
 
-	// Drop previous unpack so a build upgrade cannot leave stale plugin jars behind.
-	_ = os.RemoveAll(filepath.Join(targetDir, "custom-plugins"))
-	_ = os.Remove(filepath.Join(targetDir, "disabled_plugins.txt"))
-	_ = os.Remove(filepath.Join(targetDir, customPluginsSourceFile))
-
-	archivePath := filepath.Join(targetDir, "custom-plugins.zip")
-	err := utils.DownloadFile(archivePath, pluginsUrl, getInternalAuth(), spinner)
+	// Stage into a temp dir first so a failed download/unpack keeps the previous cache intact.
+	stagingDir, err := os.MkdirTemp(targetDir, "custom-plugins.*.partial")
 	if err != nil {
-		return fmt.Errorf("error while downloading plugins: %v", err)
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("couldn't create staging directory: %v", err))
 	}
 	defer func() {
-		if removeErr := os.Remove(archivePath); removeErr != nil && !os.IsNotExist(removeErr) {
-			log.Warning("Error while removing custom plugins archive: " + removeErr.Error())
+		if removeErr := os.RemoveAll(stagingDir); removeErr != nil {
+			log.Warning("Error while removing custom plugins staging directory: " + removeErr.Error())
 		}
 	}()
 
-	_, err = fexec.Exec(".", "tar", "-xf", archivePath, "-C", targetDir)
+	archivePath := filepath.Join(stagingDir, "custom-plugins.zip")
+	err = utils.DownloadFile(archivePath, pluginsUrl, getInternalAuth(), spinner)
 	if err != nil {
-		return fmt.Errorf("tar: %s", err)
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("error while downloading plugins: %v", err))
 	}
 
-	disabledPluginsPath := filepath.Join(targetDir, "custom-plugins", "disabled_plugins.txt")
-	err = cp.Copy(disabledPluginsPath, filepath.Join(targetDir, "disabled_plugins.txt"))
+	_, err = fexec.Exec(".", "tar", "-xf", archivePath, "-C", stagingDir)
 	if err != nil {
-		return fmt.Errorf("error while copying plugins: %s", err)
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("tar: %s", err))
 	}
 
-	if err := os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644); err != nil {
-		return fmt.Errorf("error while writing custom plugins source marker: %v", err)
+	stagingPlugins := filepath.Join(stagingDir, "custom-plugins")
+	stagingDisabled := filepath.Join(stagingDir, "disabled_plugins.txt")
+	err = cp.Copy(filepath.Join(stagingPlugins, "disabled_plugins.txt"), stagingDisabled)
+	if err != nil {
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("error while copying plugins: %s", err))
+	}
+
+	if err := os.WriteFile(filepath.Join(stagingDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644); err != nil {
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("error while writing custom plugins source marker: %v", err))
+	}
+
+	if err := installCustomPluginsFromStaging(targetDir, stagingDir); err != nil {
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, err)
+	}
+
+	return nil
+}
+
+func hasCustomPluginsInstall(targetDir string) bool {
+	info, err := os.Stat(filepath.Join(targetDir, "custom-plugins"))
+	return err == nil && info.IsDir()
+}
+
+// failedCustomPluginsUpdate logs update failures. When a previous install exists it
+// stays on disk (staging never replaced it, or install was rolled back), so the
+// warning says we are keeping it.
+func failedCustomPluginsUpdate(pluginsUrl string, hadPrevious bool, err error) error {
+	if hadPrevious {
+		log.Warningf("Failed to update custom plugins from %s, keeping previously cached plugins: %v", pluginsUrl, err)
+		return err
+	}
+	log.Warningf("Failed to update custom plugins from %s: %v", pluginsUrl, err)
+	return err
+}
+
+func cleanupStaleCustomPluginsStaging(targetDir string) {
+	matches, err := filepath.Glob(filepath.Join(targetDir, "custom-plugins.*.partial"))
+	if err != nil {
+		return
+	}
+	for _, match := range matches {
+		if err := os.RemoveAll(match); err != nil {
+			log.Warningf("Failed to remove stale custom plugins staging directory %s: %s", match, err)
+		}
+	}
+}
+
+// installCustomPluginsFromStaging replaces the live custom-plugins tree only after
+// staging is complete. The previous tree is moved aside first so a rename failure
+// can roll back instead of leaving an empty cache. The source marker is written
+// last; any removal failure aborts before that so the old URL marker is kept.
+func installCustomPluginsFromStaging(targetDir string, stagingDir string) error {
+	finalPlugins := filepath.Join(targetDir, "custom-plugins")
+	stagingPlugins := filepath.Join(stagingDir, "custom-plugins")
+	backupPlugins := filepath.Join(targetDir, "custom-plugins.old")
+
+	if err := os.RemoveAll(backupPlugins); err != nil {
+		return fmt.Errorf("failed to remove leftover custom plugins backup: %w", err)
+	}
+
+	hadPrevious := false
+	if info, err := os.Stat(finalPlugins); err == nil && info.IsDir() {
+		if err := os.Rename(finalPlugins, backupPlugins); err != nil {
+			return fmt.Errorf("failed to move previous custom plugins aside: %w", err)
+		}
+		hadPrevious = true
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat custom plugins directory: %w", err)
+	}
+
+	if err := os.Rename(stagingPlugins, finalPlugins); err != nil {
+		if hadPrevious {
+			if rollbackErr := os.Rename(backupPlugins, finalPlugins); rollbackErr != nil {
+				log.Warningf("Failed to roll back custom plugins after install error: %s", rollbackErr)
+			}
+		}
+		return fmt.Errorf("failed to install custom plugins: %w", err)
+	}
+
+	if hadPrevious {
+		if err := os.RemoveAll(backupPlugins); err != nil {
+			// New tree is already in place; put the previous one back and leave the
+			// URL marker untouched so the cache is not claimed as updated.
+			if rbErr := os.Rename(finalPlugins, stagingPlugins); rbErr != nil {
+				log.Warningf("Failed to undo custom plugins install after removal error: %s", rbErr)
+			} else if rbErr := os.Rename(backupPlugins, finalPlugins); rbErr != nil {
+				log.Warningf("Failed to roll back custom plugins after removal error: %s", rbErr)
+			}
+			return fmt.Errorf("failed to remove previous custom plugins: %w", err)
+		}
+	}
+
+	if err := os.Rename(filepath.Join(stagingDir, "disabled_plugins.txt"), filepath.Join(targetDir, "disabled_plugins.txt")); err != nil {
+		return fmt.Errorf("failed to install disabled_plugins.txt: %w", err)
+	}
+	if err := os.Rename(filepath.Join(stagingDir, customPluginsSourceFile), filepath.Join(targetDir, customPluginsSourceFile)); err != nil {
+		return fmt.Errorf("failed to install custom plugins source marker: %w", err)
 	}
 
 	return nil
@@ -427,8 +519,13 @@ func isCustomPluginsCacheValid(targetDir string, pluginsUrl string) bool {
 	if _, err := os.Stat(filepath.Join(targetDir, "disabled_plugins.txt")); err != nil {
 		return false
 	}
-	info, err := os.Stat(filepath.Join(targetDir, "custom-plugins"))
+	pluginsDir := filepath.Join(targetDir, "custom-plugins")
+	info, err := os.Stat(pluginsDir)
 	if err != nil || !info.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(pluginsDir)
+	if err != nil || len(entries) == 0 {
 		return false
 	}
 	data, err := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))

--- a/internal/core/startup/installers.go
+++ b/internal/core/startup/installers.go
@@ -408,9 +408,14 @@ func downloadCustomPlugins(ideUrl string, targetDir string, spinner *pterm.Spinn
 		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("error while downloading plugins: %v", err))
 	}
 
-	_, err = fexec.Exec(".", "tar", "-xf", archivePath, "-C", stagingDir)
+	// fexec.Exec returns a nil error for normal non-zero process exits; only the
+	// exit code signals tar failure (e.g. partial extract of a malformed archive).
+	exitCode, err := fexec.Exec(".", "tar", "-xf", archivePath, "-C", stagingDir)
 	if err != nil {
-		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("tar: %s", err))
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("tar: %w", err))
+	}
+	if exitCode != 0 {
+		return failedCustomPluginsUpdate(pluginsUrl, hadPrevious, fmt.Errorf("tar: exit code %d", exitCode))
 	}
 
 	stagingPlugins := filepath.Join(stagingDir, "custom-plugins")

--- a/internal/core/startup/installers.go
+++ b/internal/core/startup/installers.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 
 	fexec "github.com/JetBrains/qodana-cli/internal/foundation/exec"
+	"github.com/JetBrains/qodana-cli/internal/foundation/flock"
 	"github.com/JetBrains/qodana-cli/internal/platform"
 	"github.com/JetBrains/qodana-cli/internal/platform/msg"
 	"github.com/JetBrains/qodana-cli/internal/platform/product"
@@ -377,6 +378,9 @@ func verifySha256(checksumFile string, checkSumUrl string, filePath string) {
 // the build number) is what invalidates the cache across patch releases.
 const customPluginsSourceFile = "custom-plugins.source"
 
+// customPluginsLockFile coordinates concurrent downloads into the same targetDir.
+const customPluginsLockFile = "custom-plugins.lock"
+
 func downloadCustomPlugins(ideUrl string, targetDir string, spinner *pterm.SpinnerPrinter) error {
 	pluginsUrl := getPluginsURL(ideUrl)
 	if isCustomPluginsCacheValid(targetDir, pluginsUrl) {
@@ -384,6 +388,24 @@ func downloadCustomPlugins(ideUrl string, targetDir string, spinner *pterm.Spinn
 		return nil
 	}
 
+	// Exclusive lock so concurrent runs for the same version-branch wait instead of
+	// racing on staging/install. Re-check the cache after acquiring — another process
+	// may have finished the download while we waited.
+	lockPath := filepath.Join(targetDir, customPluginsLockFile)
+	var downloadErr error
+	if err := flock.With(lockPath, func() {
+		if isCustomPluginsCacheValid(targetDir, pluginsUrl) {
+			log.Debugf("Custom plugins already downloaded from %s to %s (updated by another process), skipping download", pluginsUrl, targetDir)
+			return
+		}
+		downloadErr = downloadAndInstallCustomPlugins(pluginsUrl, targetDir, spinner)
+	}); err != nil {
+		return failedCustomPluginsUpdate(pluginsUrl, hasCustomPluginsInstall(targetDir), fmt.Errorf("couldn't acquire custom plugins lock: %w", err))
+	}
+	return downloadErr
+}
+
+func downloadAndInstallCustomPlugins(pluginsUrl string, targetDir string, spinner *pterm.SpinnerPrinter) error {
 	log.Debugf("Downloading custom plugins from %s to %s", pluginsUrl, targetDir)
 	hadPrevious := hasCustomPluginsInstall(targetDir)
 

--- a/internal/core/startup/installers.go
+++ b/internal/core/startup/installers.go
@@ -371,19 +371,39 @@ func verifySha256(checksumFile string, checkSumUrl string, filePath string) {
 	log.Info("Checksum of downloaded IDE was verified")
 }
 
+// customPluginsSourceFile stores the plugins URL used to populate the cache.
+// Custom plugins live under <code>/<version-branch>/, so the URL (which includes
+// the build number) is what invalidates the cache across patch releases.
+const customPluginsSourceFile = "custom-plugins.source"
+
 func downloadCustomPlugins(ideUrl string, targetDir string, spinner *pterm.SpinnerPrinter) error {
 	pluginsUrl := getPluginsURL(ideUrl)
+	if isCustomPluginsCacheValid(targetDir, pluginsUrl) {
+		log.Debugf("Custom plugins already downloaded from %s to %s, skipping download", pluginsUrl, targetDir)
+		return nil
+	}
+
 	log.Debugf("Downloading custom plugins from %s to %s", pluginsUrl, targetDir)
 
 	if err := os.MkdirAll(targetDir, os.ModePerm); err != nil {
 		return fmt.Errorf("couldn't create a directory %s: %v", targetDir, err)
 	}
 
+	// Drop previous unpack so a build upgrade cannot leave stale plugin jars behind.
+	_ = os.RemoveAll(filepath.Join(targetDir, "custom-plugins"))
+	_ = os.Remove(filepath.Join(targetDir, "disabled_plugins.txt"))
+	_ = os.Remove(filepath.Join(targetDir, customPluginsSourceFile))
+
 	archivePath := filepath.Join(targetDir, "custom-plugins.zip")
 	err := utils.DownloadFile(archivePath, pluginsUrl, getInternalAuth(), spinner)
 	if err != nil {
 		return fmt.Errorf("error while downloading plugins: %v", err)
 	}
+	defer func() {
+		if removeErr := os.Remove(archivePath); removeErr != nil && !os.IsNotExist(removeErr) {
+			log.Warning("Error while removing custom plugins archive: " + removeErr.Error())
+		}
+	}()
 
 	_, err = fexec.Exec(".", "tar", "-xf", archivePath, "-C", targetDir)
 	if err != nil {
@@ -396,7 +416,26 @@ func downloadCustomPlugins(ideUrl string, targetDir string, spinner *pterm.Spinn
 		return fmt.Errorf("error while copying plugins: %s", err)
 	}
 
+	if err := os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644); err != nil {
+		return fmt.Errorf("error while writing custom plugins source marker: %v", err)
+	}
+
 	return nil
+}
+
+func isCustomPluginsCacheValid(targetDir string, pluginsUrl string) bool {
+	if _, err := os.Stat(filepath.Join(targetDir, "disabled_plugins.txt")); err != nil {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(targetDir, "custom-plugins"))
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == pluginsUrl
 }
 
 func getPluginsURL(ideUrl string) string {

--- a/internal/core/startup/installers.go
+++ b/internal/core/startup/installers.go
@@ -19,6 +19,7 @@ package startup
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -484,7 +485,7 @@ func installCustomPluginsFromStaging(targetDir string, stagingDir string) error 
 			return fmt.Errorf("failed to move previous custom plugins aside: %w", err)
 		}
 		hadPrevious = true
-	} else if err != nil && !os.IsNotExist(err) {
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to stat custom plugins directory: %w", err)
 	}
 

--- a/internal/core/startup/installers_test.go
+++ b/internal/core/startup/installers_test.go
@@ -19,6 +19,7 @@ package startup
 import (
 	"archive/tar"
 	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -37,6 +38,7 @@ import (
 	"github.com/JetBrains/qodana-cli/internal/platform/msg"
 	"github.com/JetBrains/qodana-cli/internal/platform/product"
 	"github.com/JetBrains/qodana-cli/internal/testutil/mockexe"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -295,32 +297,75 @@ func TestExtractArchiveBadPath(t *testing.T) {
 func TestIsCustomPluginsCacheValid(t *testing.T) {
 	pluginsUrl := "https://example.com/qodana-QDJVM-262.9643.87-custom-plugins.zip"
 
+	seedCache := func(t *testing.T, targetDir string, url string, withPlugin bool) {
+		t.Helper()
+		pluginsDir := filepath.Join(targetDir, "custom-plugins")
+		assert.NoError(t, os.MkdirAll(pluginsDir, 0o755))
+		if withPlugin {
+			assert.NoError(t, os.WriteFile(filepath.Join(pluginsDir, "plugin.jar"), []byte("jar"), 0o644))
+		}
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(url), 0o644))
+	}
+
 	t.Run("missing cache", func(t *testing.T) {
 		assert.False(t, isCustomPluginsCacheValid(t.TempDir(), pluginsUrl))
 	})
 
 	t.Run("valid cache", func(t *testing.T) {
 		targetDir := t.TempDir()
-		assert.NoError(t, os.MkdirAll(filepath.Join(targetDir, "custom-plugins"), 0o755))
-		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
-		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644))
+		seedCache(t, targetDir, pluginsUrl, true)
 		assert.True(t, isCustomPluginsCacheValid(targetDir, pluginsUrl))
 	})
 
 	t.Run("url mismatch", func(t *testing.T) {
 		targetDir := t.TempDir()
-		assert.NoError(t, os.MkdirAll(filepath.Join(targetDir, "custom-plugins"), 0o755))
-		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
-		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644))
+		seedCache(t, targetDir, pluginsUrl, true)
 		assert.False(t, isCustomPluginsCacheValid(targetDir, pluginsUrl+"-other"))
 	})
 
 	t.Run("legacy cache without source marker", func(t *testing.T) {
 		targetDir := t.TempDir()
 		assert.NoError(t, os.MkdirAll(filepath.Join(targetDir, "custom-plugins"), 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "custom-plugins", "plugin.jar"), []byte("jar"), 0o644))
 		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
 		assert.False(t, isCustomPluginsCacheValid(targetDir, pluginsUrl))
 	})
+
+	t.Run("empty custom-plugins directory", func(t *testing.T) {
+		targetDir := t.TempDir()
+		seedCache(t, targetDir, pluginsUrl, false)
+		assert.False(t, isCustomPluginsCacheValid(targetDir, pluginsUrl))
+	})
+
+	t.Run("custom-plugins is a file", func(t *testing.T) {
+		targetDir := t.TempDir()
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "custom-plugins"), []byte("not-a-dir"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644))
+		assert.False(t, isCustomPluginsCacheValid(targetDir, pluginsUrl))
+	})
+}
+
+func TestGetPluginsURL(t *testing.T) {
+	assert.Equal(t, "https://example.com/ide-custom-plugins.zip", getPluginsURL("https://example.com/ide.sit"))
+	assert.Equal(t, "https://example.com/ide-custom-plugins.zip", getPluginsURL("https://example.com/ide-aarch64.sit"))
+	assert.Equal(t, "https://example.com/ide-custom-plugins.zip", getPluginsURL("https://example.com/ide.win.zip"))
+	assert.Equal(t, "https://example.com/ide-custom-plugins.zip", getPluginsURL("https://example.com/ide.tar.gz"))
+}
+
+func captureLogWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var logBuf bytes.Buffer
+	prevOut := log.StandardLogger().Out
+	prevLevel := log.GetLevel()
+	log.SetOutput(&logBuf)
+	log.SetLevel(log.WarnLevel)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetLevel(prevLevel)
+	})
+	return &logBuf
 }
 
 func TestDownloadCustomPlugins(t *testing.T) {
@@ -354,6 +399,7 @@ func TestDownloadCustomPlugins(t *testing.T) {
 	defer server.Close()
 
 	// downloadCustomPlugins is only called on macOS, where IDE URLs use .sit extensions.
+	// DownloadFile issues HEAD then GET, so one logical download is two HTTP requests.
 	t.Run(".sit", func(t *testing.T) {
 		downloads.Store(0)
 		targetDir := filepath.Join(t.TempDir(), "plugins")
@@ -362,11 +408,11 @@ func TestDownloadCustomPlugins(t *testing.T) {
 		assert.FileExists(t, filepath.Join(targetDir, "disabled_plugins.txt"))
 		assert.FileExists(t, filepath.Join(targetDir, customPluginsSourceFile))
 		assert.NoFileExists(t, filepath.Join(targetDir, "custom-plugins.zip"))
-		assert.Equal(t, int32(1), downloads.Load())
+		assert.Equal(t, int32(2), downloads.Load())
 
 		err = downloadCustomPlugins(server.URL+"/ide.sit", targetDir, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, int32(1), downloads.Load(), "second call should use cache")
+		assert.Equal(t, int32(2), downloads.Load(), "second call should use cache")
 	})
 	t.Run("-aarch64.sit", func(t *testing.T) {
 		downloads.Store(0)
@@ -374,19 +420,138 @@ func TestDownloadCustomPlugins(t *testing.T) {
 		err := downloadCustomPlugins(server.URL+"/ide-aarch64.sit", targetDir, nil)
 		assert.NoError(t, err)
 		assert.FileExists(t, filepath.Join(targetDir, "disabled_plugins.txt"))
-		assert.Equal(t, int32(1), downloads.Load())
+		assert.Equal(t, int32(2), downloads.Load())
 	})
 	t.Run("re-downloads when url changes", func(t *testing.T) {
 		downloads.Store(0)
 		targetDir := filepath.Join(t.TempDir(), "plugins")
 		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide-262.1.sit", targetDir, nil))
-		assert.Equal(t, int32(1), downloads.Load())
+		assert.Equal(t, int32(2), downloads.Load())
 
 		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide-262.2.sit", targetDir, nil))
-		assert.Equal(t, int32(2), downloads.Load())
+		assert.Equal(t, int32(4), downloads.Load())
 		source, err := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
 		assert.NoError(t, err)
 		assert.Equal(t, server.URL+"/ide-262.2-custom-plugins.zip", strings.TrimSpace(string(source)))
+	})
+	t.Run("keeps previous cache when download fails", func(t *testing.T) {
+		targetDir := filepath.Join(t.TempDir(), "plugins")
+		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide-262.1.sit", targetDir, nil))
+		assert.FileExists(t, filepath.Join(targetDir, "disabled_plugins.txt"))
+		assert.DirExists(t, filepath.Join(targetDir, "custom-plugins"))
+
+		failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+		}))
+		defer failing.Close()
+
+		logBuf := captureLogWarnings(t)
+		err := downloadCustomPlugins(failing.URL+"/ide-262.2.sit", targetDir, nil)
+		assert.Error(t, err)
+		assert.Contains(t, logBuf.String(), "keeping previously cached plugins")
+		assert.FileExists(t, filepath.Join(targetDir, "disabled_plugins.txt"))
+		assert.DirExists(t, filepath.Join(targetDir, "custom-plugins"))
+		source, readErr := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoError(t, readErr)
+		assert.Equal(t, server.URL+"/ide-262.1-custom-plugins.zip", strings.TrimSpace(string(source)))
+		assert.NoFileExists(t, filepath.Join(targetDir, "custom-plugins.old"))
+		matches, globErr := filepath.Glob(filepath.Join(targetDir, "custom-plugins.*.partial"))
+		assert.NoError(t, globErr)
+		assert.Empty(t, matches)
+	})
+	t.Run("logs failure on first install", func(t *testing.T) {
+		failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+		}))
+		defer failing.Close()
+
+		logBuf := captureLogWarnings(t)
+		err := downloadCustomPlugins(failing.URL+"/ide.sit", filepath.Join(t.TempDir(), "plugins"), nil)
+		assert.Error(t, err)
+		assert.Contains(t, logBuf.String(), "Failed to update custom plugins")
+		assert.NotContains(t, logBuf.String(), "keeping previously cached plugins")
+	})
+	t.Run("logs failure when archive is corrupt", func(t *testing.T) {
+		bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			payload := []byte("not-a-zip")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+			_, _ = w.Write(payload)
+		}))
+		defer bad.Close()
+
+		logBuf := captureLogWarnings(t)
+		err := downloadCustomPlugins(bad.URL+"/ide.sit", filepath.Join(t.TempDir(), "plugins"), nil)
+		assert.Error(t, err)
+		assert.Contains(t, logBuf.String(), "Failed to update custom plugins")
+		assert.NotContains(t, logBuf.String(), "keeping previously cached plugins")
+	})
+	t.Run("removes stale staging directories", func(t *testing.T) {
+		targetDir := filepath.Join(t.TempDir(), "plugins")
+		assert.NoError(t, os.MkdirAll(targetDir, 0o755))
+		stale := filepath.Join(targetDir, "custom-plugins.12345.partial")
+		assert.NoError(t, os.MkdirAll(filepath.Join(stale, "junk"), 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(stale, "junk", "x"), []byte("x"), 0o644))
+
+		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide.sit", targetDir, nil))
+		matches, err := filepath.Glob(filepath.Join(targetDir, "custom-plugins.*.partial"))
+		assert.NoError(t, err)
+		assert.Empty(t, matches)
+		assert.FileExists(t, filepath.Join(targetDir, customPluginsSourceFile))
+	})
+	t.Run("aborts when previous plugins cannot be removed", func(t *testing.T) {
+		targetDir := filepath.Join(t.TempDir(), "plugins")
+		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide-262.1.sit", targetDir, nil))
+		oldMarker, err := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoError(t, err)
+
+		// Leftover backup that cannot be deleted blocks the update before any swap.
+		backupPlugins := filepath.Join(targetDir, "custom-plugins.old")
+		nested := filepath.Join(backupPlugins, "nested")
+		assert.NoError(t, os.MkdirAll(nested, 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(nested, "stuck.txt"), []byte("x"), 0o644))
+		assert.NoError(t, os.Chmod(nested, 0o000))
+		t.Cleanup(func() {
+			_ = os.Chmod(nested, 0o755)
+			_ = os.RemoveAll(backupPlugins)
+		})
+
+		logBuf := captureLogWarnings(t)
+		err = downloadCustomPlugins(server.URL+"/ide-262.2.sit", targetDir, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to remove leftover custom plugins backup")
+		assert.Contains(t, logBuf.String(), "keeping previously cached plugins")
+		source, readErr := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoError(t, readErr)
+		assert.Equal(t, string(oldMarker), string(source), "URL marker must stay unchanged")
+		assert.DirExists(t, filepath.Join(targetDir, "custom-plugins"))
+	})
+	t.Run("rolls back when old plugins cannot be deleted after swap", func(t *testing.T) {
+		targetDir := filepath.Join(t.TempDir(), "plugins")
+		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide-262.1.sit", targetDir, nil))
+		oldMarker, err := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoError(t, err)
+
+		// Once moved to custom-plugins.old, this nested dir cannot be removed.
+		nested := filepath.Join(targetDir, "custom-plugins", "nested")
+		assert.NoError(t, os.MkdirAll(nested, 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(nested, "stuck.txt"), []byte("x"), 0o644))
+		assert.NoError(t, os.Chmod(nested, 0o000))
+		t.Cleanup(func() {
+			_ = os.Chmod(filepath.Join(targetDir, "custom-plugins", "nested"), 0o755)
+			_ = os.Chmod(filepath.Join(targetDir, "custom-plugins.old", "nested"), 0o755)
+			_ = os.RemoveAll(filepath.Join(targetDir, "custom-plugins.old"))
+		})
+
+		logBuf := captureLogWarnings(t)
+		err = downloadCustomPlugins(server.URL+"/ide-262.2.sit", targetDir, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to remove previous custom plugins")
+		assert.Contains(t, logBuf.String(), "keeping previously cached plugins")
+		source, readErr := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoError(t, readErr)
+		assert.Equal(t, string(oldMarker), string(source), "URL marker must stay unchanged")
+		assert.DirExists(t, filepath.Join(targetDir, "custom-plugins", "nested"))
+		assert.NoDirExists(t, filepath.Join(targetDir, "custom-plugins.old"))
 	})
 }
 

--- a/internal/core/startup/installers_test.go
+++ b/internal/core/startup/installers_test.go
@@ -21,8 +21,10 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -368,6 +370,34 @@ func captureLogWarnings(t *testing.T) *bytes.Buffer {
 	return &logBuf
 }
 
+// malformedPluginsZipPartialExtract builds a zip whose first member extracts cleanly
+// and whose second member is truncated, so bsdtar exits non-zero after creating
+// custom-plugins/disabled_plugins.txt.
+func malformedPluginsZipPartialExtract(t *testing.T) []byte {
+	t.Helper()
+	localFile := func(name string, data []byte, truncate bool) []byte {
+		nameBytes := []byte(name)
+		crc := crc32.ChecksumIEEE(data)
+		header := make([]byte, 30)
+		binary.LittleEndian.PutUint32(header[0:], 0x04034b50)
+		binary.LittleEndian.PutUint16(header[8:], 0) // stored
+		binary.LittleEndian.PutUint32(header[14:], crc)
+		binary.LittleEndian.PutUint32(header[18:], uint32(len(data)))
+		binary.LittleEndian.PutUint32(header[22:], uint32(len(data)))
+		binary.LittleEndian.PutUint16(header[26:], uint16(len(nameBytes)))
+		out := append(append(header, nameBytes...), data...)
+		if truncate {
+			keep := 30 + len(nameBytes) + max(1, len(data)/3)
+			return out[:keep]
+		}
+		return out
+	}
+	var out []byte
+	out = append(out, localFile("custom-plugins/disabled_plugins.txt", []byte("id\n"), false)...)
+	out = append(out, localFile("custom-plugins/plugin.jar", bytes.Repeat([]byte("J"), 200), true)...)
+	return out
+}
+
 func TestDownloadCustomPlugins(t *testing.T) {
 	//goland:noinspection GoBoolExpressions
 	if runtime.GOOS != "darwin" {
@@ -482,8 +512,28 @@ func TestDownloadCustomPlugins(t *testing.T) {
 		logBuf := captureLogWarnings(t)
 		err := downloadCustomPlugins(bad.URL+"/ide.sit", filepath.Join(t.TempDir(), "plugins"), nil)
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "tar: exit code")
 		assert.Contains(t, logBuf.String(), "Failed to update custom plugins")
 		assert.NotContains(t, logBuf.String(), "keeping previously cached plugins")
+	})
+	t.Run("rejects partial extract from malformed archive", func(t *testing.T) {
+		// First local-file entry is intact; second is truncated so bsdtar exits
+		// non-zero after already writing custom-plugins/disabled_plugins.txt.
+		payload := malformedPluginsZipPartialExtract(t)
+		bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+			_, _ = w.Write(payload)
+		}))
+		defer bad.Close()
+
+		targetDir := filepath.Join(t.TempDir(), "plugins")
+		logBuf := captureLogWarnings(t)
+		err := downloadCustomPlugins(bad.URL+"/ide.sit", targetDir, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "tar: exit code")
+		assert.Contains(t, logBuf.String(), "Failed to update custom plugins")
+		assert.NoFileExists(t, filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoDirExists(t, filepath.Join(targetDir, "custom-plugins"))
 	})
 	t.Run("removes stale staging directories", func(t *testing.T) {
 		targetDir := filepath.Join(t.TempDir(), "plugins")

--- a/internal/core/startup/installers_test.go
+++ b/internal/core/startup/installers_test.go
@@ -29,6 +29,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -291,10 +292,41 @@ func TestExtractArchiveBadPath(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestIsCustomPluginsCacheValid(t *testing.T) {
+	pluginsUrl := "https://example.com/qodana-QDJVM-262.9643.87-custom-plugins.zip"
+
+	t.Run("missing cache", func(t *testing.T) {
+		assert.False(t, isCustomPluginsCacheValid(t.TempDir(), pluginsUrl))
+	})
+
+	t.Run("valid cache", func(t *testing.T) {
+		targetDir := t.TempDir()
+		assert.NoError(t, os.MkdirAll(filepath.Join(targetDir, "custom-plugins"), 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644))
+		assert.True(t, isCustomPluginsCacheValid(targetDir, pluginsUrl))
+	})
+
+	t.Run("url mismatch", func(t *testing.T) {
+		targetDir := t.TempDir()
+		assert.NoError(t, os.MkdirAll(filepath.Join(targetDir, "custom-plugins"), 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, customPluginsSourceFile), []byte(pluginsUrl), 0o644))
+		assert.False(t, isCustomPluginsCacheValid(targetDir, pluginsUrl+"-other"))
+	})
+
+	t.Run("legacy cache without source marker", func(t *testing.T) {
+		targetDir := t.TempDir()
+		assert.NoError(t, os.MkdirAll(filepath.Join(targetDir, "custom-plugins"), 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "disabled_plugins.txt"), []byte("id\n"), 0o644))
+		assert.False(t, isCustomPluginsCacheValid(targetDir, pluginsUrl))
+	})
+}
+
 func TestDownloadCustomPlugins(t *testing.T) {
 	//goland:noinspection GoBoolExpressions
 	if runtime.GOOS != "darwin" {
-		t.Skip("downloadCustomPlugins is only used on macOS")
+		t.Skip("downloadCustomPlugins uses macOS tar zip extraction")
 	}
 
 	// Create a zip archive containing custom-plugins/disabled_plugins.txt
@@ -313,7 +345,9 @@ func TestDownloadCustomPlugins(t *testing.T) {
 	archiveBytes, err := os.ReadFile(archivePath)
 	assert.NoError(t, err)
 
+	var downloads atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downloads.Add(1)
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(archiveBytes)))
 		_, _ = w.Write(archiveBytes)
 	}))
@@ -321,16 +355,38 @@ func TestDownloadCustomPlugins(t *testing.T) {
 
 	// downloadCustomPlugins is only called on macOS, where IDE URLs use .sit extensions.
 	t.Run(".sit", func(t *testing.T) {
+		downloads.Store(0)
 		targetDir := filepath.Join(t.TempDir(), "plugins")
 		err := downloadCustomPlugins(server.URL+"/ide.sit", targetDir, nil)
 		assert.NoError(t, err)
 		assert.FileExists(t, filepath.Join(targetDir, "disabled_plugins.txt"))
+		assert.FileExists(t, filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoFileExists(t, filepath.Join(targetDir, "custom-plugins.zip"))
+		assert.Equal(t, int32(1), downloads.Load())
+
+		err = downloadCustomPlugins(server.URL+"/ide.sit", targetDir, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1), downloads.Load(), "second call should use cache")
 	})
 	t.Run("-aarch64.sit", func(t *testing.T) {
+		downloads.Store(0)
 		targetDir := filepath.Join(t.TempDir(), "plugins")
 		err := downloadCustomPlugins(server.URL+"/ide-aarch64.sit", targetDir, nil)
 		assert.NoError(t, err)
 		assert.FileExists(t, filepath.Join(targetDir, "disabled_plugins.txt"))
+		assert.Equal(t, int32(1), downloads.Load())
+	})
+	t.Run("re-downloads when url changes", func(t *testing.T) {
+		downloads.Store(0)
+		targetDir := filepath.Join(t.TempDir(), "plugins")
+		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide-262.1.sit", targetDir, nil))
+		assert.Equal(t, int32(1), downloads.Load())
+
+		assert.NoError(t, downloadCustomPlugins(server.URL+"/ide-262.2.sit", targetDir, nil))
+		assert.Equal(t, int32(2), downloads.Load())
+		source, err := os.ReadFile(filepath.Join(targetDir, customPluginsSourceFile))
+		assert.NoError(t, err)
+		assert.Equal(t, server.URL+"/ide-262.2-custom-plugins.zip", strings.TrimSpace(string(source)))
 	})
 }
 

--- a/internal/core/startup/installers_test.go
+++ b/internal/core/startup/installers_test.go
@@ -33,8 +33,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/JetBrains/qodana-cli/internal/foundation/fs"
 	"github.com/JetBrains/qodana-cli/internal/platform/msg"
@@ -602,6 +604,41 @@ func TestDownloadCustomPlugins(t *testing.T) {
 		assert.Equal(t, string(oldMarker), string(source), "URL marker must stay unchanged")
 		assert.DirExists(t, filepath.Join(targetDir, "custom-plugins", "nested"))
 		assert.NoDirExists(t, filepath.Join(targetDir, "custom-plugins.old"))
+	})
+	t.Run("serializes concurrent downloads", func(t *testing.T) {
+		var concurrentDownloads atomic.Int32
+		var requests atomic.Int32
+		countingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			if concurrentDownloads.Add(1) > 1 {
+				t.Error("overlapping custom-plugins downloads")
+			}
+			defer concurrentDownloads.Add(-1)
+			time.Sleep(200 * time.Millisecond)
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(archiveBytes)))
+			_, _ = w.Write(archiveBytes)
+		}))
+		defer countingServer.Close()
+
+		targetDir := filepath.Join(t.TempDir(), "plugins")
+		var wg sync.WaitGroup
+		errs := make(chan error, 2)
+		for range 2 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errs <- downloadCustomPlugins(countingServer.URL+"/ide.sit", targetDir, nil)
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			assert.NoError(t, err)
+		}
+		// One logical download is HEAD+GET; the second waiter should reuse the cache.
+		assert.Equal(t, int32(2), requests.Load())
+		assert.FileExists(t, filepath.Join(targetDir, customPluginsSourceFile))
+		assert.FileExists(t, filepath.Join(targetDir, customPluginsLockFile))
 	})
 }
 

--- a/internal/core/startup/prepare.go
+++ b/internal/core/startup/prepare.go
@@ -159,10 +159,9 @@ func prepareQodanaTokenForNative(token string) {
 func prepareCustomPlugins(prod product.Product) {
 	if runtime.GOOS == "darwin" && !prod.Analyzer.IsContainer() {
 		if info := getIde(prod.Analyzer); info != nil {
-			err := downloadCustomPlugins(info.Link, filepath.Dir(prod.CustomPluginsPath()), nil)
-			if err != nil {
-				log.Warning("Error while downloading custom plugins: " + err.Error())
-			}
+			// Failures are logged inside downloadCustomPlugins, including when a
+			// previous cache is kept after an unsuccessful update.
+			_ = downloadCustomPlugins(info.Link, filepath.Dir(prod.CustomPluginsPath()), nil)
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request Details

Added custom-plugins.zip caching.

## Description

Native macOS runs used to re-download custom plugins every time. The branch caches them under the version-branch dir, keyed by the plugins URL (build number), and skips the download when the cache is valid (non-empty custom-plugins + matching source marker).

Updates stage into a temp dir and swap in only on success. Failed downloads or removal problems keep/roll back the previous install, leave the old URL marker, and log a warning. Covered by unit/integration tests for cache hit/miss, URL change, failure/rollback, and related edge cases.

## Related Issue

[QD-15655](https://youtrack.jetbrains.com/issue/QD-15655)

## Motivation and Context

Re-download of custom plugins eats into performance

## How Has This Been Tested
Environment: macOS (darwin), local Go toolchain; Docker not required for these tests.

Automated

go test ./internal/core/startup/ -run 'TestIsCustomPluginsCacheValid|TestGetPluginsURL|TestDownloadCustomPlugins' -count=1 -v
go test ./internal/core/startup/ ./internal/core/ ./internal/platform/product/ -count=1
Coverage check on the custom-plugins helpers via -coverprofile (happy path + failure/rollback branches)
What the tests cover

Cache hit / miss, URL change re-download, empty or non-dir custom-plugins
Failed download keeps previous cache and logs “keeping previously cached plugins”
First-install failure logging; corrupt archive failure
Stale staging cleanup; abort when leftover backup can’t be removed; rollback when post-swap removal fails (URL marker unchanged)
getPluginsURL for .sit, -aarch64.sit, .win.zip, .tar.gz

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.