### PR TITLE
:wrench: QD-14205 removing obsolete enabledPackageSearch

### DIFF
--- a/dockerfiles/android-community/included_plugins.txt
+++ b/dockerfiles/android-community/included_plugins.txt
@@ -24,7 +24,6 @@ com.intellij.uiDesigner
 org.intellij.groovy
 org.jetbrains.idea.eclipse
 org.jetbrains.idea.maven
-org.jetbrains.idea.reposearch
 org.jetbrains.kotlin
 org.jetbrains.plugins.gradle
 org.jetbrains.android

--- a/dockerfiles/android/included_plugins.txt
+++ b/dockerfiles/android/included_plugins.txt
@@ -57,7 +57,6 @@ org.intellij.groovy
 org.jetbrains.idea.eclipse
 org.jetbrains.idea.maven
 org.jetbrains.idea.gradle.dsl
-org.jetbrains.idea.reposearch
 org.jetbrains.kotlin
 org.jetbrains.plugins.gradle
 com.jetbrains.restWebServices

--- a/dockerfiles/jvm-community/included_plugins.txt
+++ b/dockerfiles/jvm-community/included_plugins.txt
@@ -18,7 +18,6 @@ com.intellij.uiDesigner
 org.intellij.groovy
 org.jetbrains.idea.eclipse
 org.jetbrains.idea.maven
-org.jetbrains.idea.reposearch
 org.jetbrains.kotlin
 org.jetbrains.plugins.gradle
 com.intellij.modules.json

--- a/dockerfiles/jvm-llm/included_plugins.txt
+++ b/dockerfiles/jvm-llm/included_plugins.txt
@@ -57,7 +57,6 @@ org.intellij.groovy
 org.jetbrains.idea.eclipse
 org.jetbrains.idea.maven
 org.jetbrains.idea.gradle.dsl
-org.jetbrains.idea.reposearch
 org.jetbrains.kotlin
 org.jetbrains.plugins.gradle
 com.jetbrains.restWebServices

--- a/dockerfiles/jvm/included_plugins.txt
+++ b/dockerfiles/jvm/included_plugins.txt
@@ -57,7 +57,6 @@ org.intellij.groovy
 org.jetbrains.idea.eclipse
 org.jetbrains.idea.maven
 org.jetbrains.idea.gradle.dsl
-org.jetbrains.idea.reposearch
 org.jetbrains.kotlin
 org.jetbrains.plugins.gradle
 com.jetbrains.restWebServices

--- a/internal/platform/qdyaml/yaml.go
+++ b/internal/platform/qdyaml/yaml.go
@@ -124,9 +124,6 @@ type QodanaYaml struct {
 	// AnalyzeDevDependencies property whether to include dev dependencies in the analysis
 	AnalyzeDevDependencies bool `yaml:"analyzeDevDependencies,omitempty"`
 
-	// EnablePackageSearch property to start using package-search service for fetching license data for dependencies (only for jvm libraries)
-	EnablePackageSearch bool `yaml:"enablePackageSearch,omitempty"`
-
 	// RaiseLicenseProblems property to show license problems like other inspections.
 	RaiseLicenseProblems bool `yaml:"raiseLicenseProblems,omitempty"`
 }


### PR DESCRIPTION
# Pull Request Details

Cleaning up qodana-cli after deprecating enablePackageSearch parameter

## Description



## Related Issue

https://youtrack.jetbrains.com/issue/QD-14205

## Motivation and Context

code cleanup, removal of not-working features

## How Has This Been Tested

Unused feature removal - manual qodana scan run with an image created with this commit.
Run doesn't crash, qodana does not log that a removed plugin is in use.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-cli/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [X] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [X] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
