### PR TITLE
:bug: QD-15753 install ICU in the C++ base images so the .NET backend doesn't FailFast

### DIFF
--- a/dockerfiles/base/cpp-community-bookworm.Dockerfile
+++ b/dockerfiles/base/cpp-community-bookworm.Dockerfile
@@ -37,6 +37,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         make \
         patch \
         libc6-dev \
+        libicu72 \
         locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \

--- a/dockerfiles/base/cpp-community.Dockerfile
+++ b/dockerfiles/base/cpp-community.Dockerfile
@@ -38,6 +38,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         make \
         patch \
         libc6-dev \
+        libicu76 \
         libpam-modules \
         locales \
         openssh-client && \


### PR DESCRIPTION
## Summary
- qodana-cpp:2026.2-rc fails to start: the .NET Radler backend (`Rider.Backend`) `FailFast`s with `Couldn't find a valid ICU package installed on the system`, not the `XDG_RUNTIME_DIR` line the ticket blames (that line is benign startup noise present in plenty of successful runs).
- Confirmed by pulling `registry.jetbrains.team/p/sa/containers/qodana-cpp:2026.2-rc` and reproducing locally; confirmed the image is Debian **trixie** (`/etc/os-release`), so `dockerfiles/base/cpp-community.Dockerfile` needs `libicu76` — added, and verified end-to-end (derived image with `libicu76` installed goes from crashing to a clean analysis run).
- Also added `libicu72` to the parallel `dockerfiles/base/cpp-community-bookworm.Dockerfile` lineage (bookworm ships ICU 72, not 76), which has the identical missing-ICU gap — not the lineage that produced this ticket, but the same defect class.

## Test plan
- [x] Built both base images locally (`docker build`) and confirmed `libicu76`/`libicu72` install cleanly.
- [x] Built a derived image (`FROM qodana-cpp:2026.2-rc` + `apt-get install libicu76`) and re-ran the crashing repro — analysis now completes (`0 problem detected`).

Fixes QD-15753.