### PR TITLE
QD-15812 Update version to 2026.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,8 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
           if [[ "$BRANCH" == "main" ]]; then
-            echo "tag=v2026.2-nightly" >> "$GITHUB_OUTPUT"
-            echo "version=2026.2-nightly" >> "$GITHUB_OUTPUT"
+            echo "tag=v2026.3-nightly" >> "$GITHUB_OUTPUT"
+            echo "version=2026.3-nightly" >> "$GITHUB_OUTPUT"
             echo "is_nightly=true" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" =~ ^[0-9]{3}$ ]]; then
             V="20${BRANCH:0:2}.${BRANCH:2}"


### PR DESCRIPTION
Updates nightly workflow version to 2026.3 for main branch builds.

This allows building CLI v2026.3-nightly while product.go remains at version 2026.2 (for linter image selection). The CLI version and linter version are intentionally decoupled to allow new CLI builds before corresponding linter images are available.