### PR TITLE
:bug: QD-13943 Use GitHub App token for post-release cross-repo PRs

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -24,6 +24,9 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: jetbrains
           repositories: qodana-action
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
 
       - uses: actions/checkout@v6
         if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
@@ -60,6 +63,9 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: jetbrains
           repositories: qodana-lsp
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
 
       - uses: actions/checkout@v6
         if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,11 +15,21 @@ jobs:
   github-actions:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: jetbrains
+          repositories: qodana-action
+
       - uses: actions/checkout@v6
         if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
         with:
           repository: 'jetbrains/qodana-action'
-          token: ${{ secrets.GH_JETBRAINS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Upgrade and send PR
@@ -37,15 +47,25 @@ jobs:
           git push origin next --force
           gh pr create --repo jetbrains/qodana-action --base main --head next --title ":arrow_up: Update \`qodana\` to the \`${VERSION}\`" --body "This automated PR updates \`qodana\` to the latest version. Please review and merge it if everything is fine."
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_JETBRAINS_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
   qodana-lsp:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: jetbrains
+          repositories: qodana-lsp
+
       - uses: actions/checkout@v6
         if: (github.event.release.name || github.event.inputs.release_name) != 'nightly'
         with:
           repository: 'jetbrains/qodana-lsp'
-          token: ${{ secrets.GH_JETBRAINS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -71,7 +91,7 @@ jobs:
           git push origin bump-cli-version --force
           gh pr create --repo jetbrains/qodana-lsp --base main --head bump-cli-version --title ":arrow_up: Update \`qodana\` to the \`${VERSION}\`" --body "This automated PR updates \`qodana\` to the latest version. Please review and merge it if everything is fine."
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_JETBRAINS_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
   winget:
     runs-on: ubuntu-latest
     if: (github.event.release.name || github.event.inputs.release_name) != 'nightly' && github.repository == 'jetbrains/qodana-cli'


### PR DESCRIPTION
# Pull Request Details                                                                                                                                                                                                                
                                                                                                                                                                                                                                        
## Description                                                                                                                                                                                                                        
                                                                                                                                                                                                                                      
Port of #1022 to `main`. Same fix, applied to `main`'s copy of `.github/workflows/post-release.yml`:                                                                                                                                  
the `github-actions` and `qodana-lsp` jobs now mint a scoped GitHub App token via                                                                                                                                                     
`actions/create-github-app-token@v2` instead of the `GH_JETBRAINS_PAT` (no `workflow` scope,                                                                                                                                          
owner without write access). `winget` is untouched.                                                                                                                                                                                   
                                                                                                                                                                                                                                      
See #1022 for full root-cause analysis and verification (App token smoke-test passed).                                                                                                                                                
                                                                                                                                                                                                                                      
## Related Issue                                                                                                                                                                                                                      
                                                                                                                                                                                                                                      
QD-13943                                                                                                                                                                                                                              
                                                                                                                                                                                                                                      
## Scope                                                                                                                                                                                                                              
                                                                                                                                                                                                                                      
Independent from the TeamCity GitHub App migration (QD-13907, `.teamcity/*.kt`), which fixed only                                                                                                                                     
the TeamCity release build. This fixes the separate GitHub Actions `post-release.yml` workflow.

## Types of changes                                                                                                                                                                                                                   
                                                                                                                                                                                                                                      
- [x] Bug fix (non-breaking change which fixes an issue)                                                                                                                                                                              
- [ ] Docs change / refactoring / dependency upgrade                                                                                                                                                                                  
- [ ] New feature (non-breaking change which adds functionality)                                                                                                                                                                      
- [ ] Breaking change (fix or feature that would cause existing functionality to change)                                                                                                                                              
                                                                                                                                                                                                                                      
## Checklist                                                                                                                                                                                                                          
                                                                                                                                                                                                                                      
- [x] I have read the **CONTRIBUTING** document.                                                                                                                                                                                      
- [x] My code follows the code style of this project.                                                                                                                                                                                 
- [x] My commit messages are styled with gitmoji.                                                                                                                                                                                     
- [ ] My change requires a change to the documentation.                                                                                                                                                                               
- [ ] I have updated the documentation accordingly.                                                                                                                                                                                   
- [ ] I have added tests to cover my changes.                                                                                                                                                                                         
- [ ] All new and existing tests passed.