### PR TITLE
:wrench: QD-15245: build a privileged variant of the poly image

### DIFF
--- a/dockerfiles/base/templates/intellij.Dockerfile.j2
+++ b/dockerfiles/base/templates/intellij.Dockerfile.j2
@@ -86,7 +86,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     chmod 777 -R $ANDROID_SDK_ROOT $HOME/.jdks/ && \
     apt-get purge --auto-remove -y unzip && \
     rm -rf /tmp/*{% endraw %}{% endif %}
-{% if variant == "ruby" or variant == "dotnet" or variant == "cpp" %}{% raw %}ARG PRIVILEGED="false"
+{% if variant == "ruby" or variant == "dotnet" or variant == "cpp" or variant == "poly" %}{% raw %}ARG PRIVILEGED="false"
 ARG SUDO_SHA256="79eef9ec144c99809c3f037b17ec0936555d7e526ac0b2688eaa8b77e1452e4f"
 RUN if [ "$PRIVILEGED" = "true" ]; then \
         apt-get update && \

--- a/dockerfiles/poly/internal.Dockerfile
+++ b/dockerfiles/poly/internal.Dockerfile
@@ -14,24 +14,19 @@ update-alternatives --set javac "$JAVA_HOME"/bin/javac
 rm -rf /var/cache/apt /var/lib/apt/ /tmp/*
 EOF
 
-# Built twice: once plain, once with PRIVILEGED=true for the "-privileged" tag (see BuildXStep in the
-# TeamCity config). The default stays "false" so the plain build really is unprivileged.
-ARG PRIVILEGED="false"
-RUN <<EOF
-set -euxo pipefail
-if [ "$PRIVILEGED" != "true" ]; then
-    echo "Skipping privileged commands because PRIVILEGED is not set to true."
-    exit 0
-fi
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y sudo
-DEBIAN_FRONTEND=noninteractive pam-auth-update --force
-useradd -m -u 1001 -U qodana
-passwd -d qodana
-echo 'qodana ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-chmod 777 /etc/passwd
-rm -rf /var/cache/apt /var/lib/apt/ /tmp/*
-EOF
+ARG PRIVILEGED="true"
+RUN if [ "$PRIVILEGED" = "true" ]; then \
+        apt-get update && \
+        apt-get install -y sudo && \
+        DEBIAN_FRONTEND=noninteractive pam-auth-update --force && \
+        useradd -m -u 1001 -U qodana && \
+        passwd -d qodana && \
+        echo 'qodana ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+        chmod 777 /etc/passwd && \
+        rm -rf /var/cache/apt /var/lib/apt/ /tmp/*; \
+    else \
+        echo "Skipping privileged commands because PRIVILEGED is not set to true."; \
+    fi
 
 LABEL maintainer="qodana-support@jetbrains.com" description="Qodana Poly (https://jb.gg/qodana-poly)"
 WORKDIR /data/project

--- a/dockerfiles/poly/internal.Dockerfile
+++ b/dockerfiles/poly/internal.Dockerfile
@@ -14,6 +14,25 @@ update-alternatives --set javac "$JAVA_HOME"/bin/javac
 rm -rf /var/cache/apt /var/lib/apt/ /tmp/*
 EOF
 
+# Built twice: once plain, once with PRIVILEGED=true for the "-privileged" tag (see BuildXStep in the
+# TeamCity config). The default stays "false" so the plain build really is unprivileged.
+ARG PRIVILEGED="false"
+RUN <<EOF
+set -euxo pipefail
+if [ "$PRIVILEGED" != "true" ]; then
+    echo "Skipping privileged commands because PRIVILEGED is not set to true."
+    exit 0
+fi
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y sudo
+DEBIAN_FRONTEND=noninteractive pam-auth-update --force
+useradd -m -u 1001 -U qodana
+passwd -d qodana
+echo 'qodana ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+chmod 777 /etc/passwd
+rm -rf /var/cache/apt /var/lib/apt/ /tmp/*
+EOF
+
 LABEL maintainer="qodana-support@jetbrains.com" description="Qodana Poly (https://jb.gg/qodana-poly)"
 WORKDIR /data/project
 ENTRYPOINT ["/opt/idea/bin/qodana"]


### PR DESCRIPTION
Renders the PRIVILEGED block for poly in the public template, and adds the matching block to the internal Dockerfile so the "-privileged" tag actually differs from the plain one. The default stays "false": the plain build passes no build arg, so a "true" default would make every internal image privileged.